### PR TITLE
Add a Skip-Nav link

### DIFF
--- a/src/components/HeaderBar.test.tsx
+++ b/src/components/HeaderBar.test.tsx
@@ -13,10 +13,9 @@ describe(HeaderBar.name, () => {
 
 const HeaderBarTestWrapper = ({ children }: ChildrenProps) => {
     return (
-        <main>
-            <MemoryRouter>
-                {children}
-            </MemoryRouter>
-        </main>
+        <MemoryRouter>
+            {children}
+            <main/>
+        </MemoryRouter>
     );
 };

--- a/src/layout/Layout.css
+++ b/src/layout/Layout.css
@@ -8,3 +8,21 @@
     overflow-y: scroll;
     padding-top: 2rem;
 }
+
+.skip-nav {
+    align-items: center;
+    background-color: #c39738;
+    box-sizing: border-box;
+    color: #062d47;
+    display: flex;
+    height: 3rem;
+    justify-content: center;
+    position: absolute;
+    top: -10rem;
+    width: 100vw;
+}
+
+.skip-nav:focus {
+    outline: 3px dashed #062d47;
+    top: 0;
+}

--- a/src/layout/Layout.test.tsx
+++ b/src/layout/Layout.test.tsx
@@ -2,10 +2,28 @@ import { Layout } from "./Layout";
 import { render, screen, within } from "@testing-library/react";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
 
 describe(Layout.name, () => {
     beforeEach(() => {
         render(<Layout/>, { wrapper: MemoryRouter });
+    });
+    test("should have a link to skip to the main landmark", () => {
+        const skipNav: HTMLLinkElement = screen.getByRole("link", { name: "Skip to content" });
+        const main = screen.getByRole("main");
+
+        expect(skipNav.href).toContain("#main-content");
+        expect(main.id).toEqual("main-content");
+    });
+    test("skip-nav link should be the first focusable element", () => {
+        const skipNav = screen.getByRole("link", { name: "Skip to content" });
+
+        userEvent.tab();
+        expect(skipNav).toHaveFocus();
+    });
+    test("main content should be focusable for Safari so skip nav link works", () => {
+        const main = screen.getByRole("main");
+        expect(main.tabIndex).toEqual(-1);
     });
     test("should render the header bar component in the header", () => {
         const header = screen.getByRole("banner");

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -6,10 +6,11 @@ import "./Layout.css";
 export const Layout = () => {
     return (
         <div className={"layout"} data-testid={"app-layout"}>
+            <a href={"#main-content"} className={"skip-nav"}>Skip to content</a>
             <header>
                 <HeaderBar/>
             </header>
-            <main className={"main-content"}>
+            <main id={"main-content"} tabIndex={-1} className={"main-content"}>
                 <RouterOutlet/>
             </main>
         </div>


### PR DESCRIPTION
Add a link to skip the keyboard's focus directly to the main content of the page. This link is hidden unless focused so mouse-users don't see it, but keyboard and screen-reader users can. It is the first focusable element in the document so keyboard users don't have to listen to or navigate through the navigation links at the top of every page before interacting with the page's content.