### PR TITLE
When a validation fails on form submit, error messages are shown to the user and the form is not submitted.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@types/jest": "^27.4.0",
     "@types/jest-axe": "^3.5.4",
     "@types/jest-when": "^3.5.0",
-    "@types/node": "^16.11.25",
     "@types/react": "^16.14.23",
     "@types/react-dom": "^16.9.14",
     "jest-axe": "^6.0.0",

--- a/src/components/form/FormField.test.tsx
+++ b/src/components/form/FormField.test.tsx
@@ -1,0 +1,141 @@
+import { FormField, FormFieldProps, FormFieldType } from "./FormField";
+import { render, screen, waitFor } from "@testing-library/react";
+import React, { useCallback, useState } from "react";
+import { Validator } from "../../hooks/form-validation/useValidation";
+import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
+import userEvent from "@testing-library/user-event";
+import { FormProvider } from "../../contexts/FormContext";
+import { Observable } from "../../utilities/observable";
+
+describe(FormField.name, () => {
+    const id = "id";
+    const name = "name";
+    let textBox: HTMLInputElement;
+    let user: UserEvent;
+
+    beforeEach(() => {
+        user = userEvent.setup();
+    });
+
+    describe("when there is no validation error", () => {
+        beforeEach(() => {
+            render(<FormField id={id} name={name} validators={[]} autocomplete={"tel"}/>);
+            textBox = screen.getByRole("textbox");
+        });
+        test("shows an input", () => {
+            expect(textBox).toBeVisible();
+        });
+        test("passes id to input", () => {
+            expect(textBox.id).toEqual(id);
+        });
+        test("passes name to input", () => {
+            expect(textBox.name).toEqual(name);
+        });
+        test("error message container is not present", () => {
+            expect(screen.queryByRole("list")).not.toBeInTheDocument();
+        });
+        test("passes autocomplete to the input", () => {
+            expect(textBox.autocomplete).toEqual("tel");
+        });
+    });
+    test("allows creating a textarea instead of an input", () => {
+        render(<FormField id={id} name={name} validators={[]} inputType={FormFieldType.TEXTAREA}/>);
+        expect(screen.getByRole("textbox")).toBeVisible();
+    });
+    describe("when there is a validation error", () => {
+        const invalidValue1 = "cheese";
+        const invalidValue2 = "eggs";
+
+        beforeEach(() => {
+            const makeValidator = (invalidValue: string): Validator => {
+                return (value: string) => {
+                    if (value.includes(invalidValue)) {
+                        return `Don't say ${invalidValue}`;
+                    }
+                    return "";
+                };
+            };
+            render(
+                <FormWithField
+                    id={id}
+                    name={name}
+                    validators={[makeValidator(invalidValue1), makeValidator(invalidValue2)]}/>,
+            );
+            textBox = screen.getByRole("textbox");
+        });
+
+        const errorMessageTestCases = [
+            { value: invalidValue1, expectedMessages: [`Don't say ${invalidValue1}`] },
+            { value: invalidValue2, expectedMessages: [`Don't say ${invalidValue2}`] },
+            {
+                value: `${invalidValue1}${invalidValue2}`,
+                expectedMessages: [`Don't say ${invalidValue1}`, `Don't say ${invalidValue2}`],
+            },
+        ];
+        errorMessageTestCases.forEach(testCase => {
+            test(`shows the error with all error messages - ${testCase.value}`, async () => {
+                await user.type(textBox, testCase.value);
+                await user.click(screen.getByRole("button"));
+
+                for (const expectedMessage of testCase.expectedMessages) {
+                    await waitFor(() => {
+                        expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+                    });
+                }
+
+                await waitFor(() => {
+                    expect(textBox).toHaveFocus();
+                });
+
+                expect(textBox.getAttribute("aria-invalid")).toEqual("true");
+                expect(textBox.getAttribute("aria-errormessage")).toEqual(`error-message-container-${id}`);
+                expect(textBox.getAttribute("aria-describedby")).toEqual(`error-message-container-${id}`);
+            });
+        });
+        describe("on blur", () => {
+            test("removes error messages that have been fixed", async () => {
+                // add value and validate to create multiple error messages
+                await user.type(textBox, `${invalidValue1}${invalidValue2}`);
+                await user.click(screen.getByRole("button"));
+                await waitFor(() => {
+                    expect(textBox).toHaveFocus();
+                });
+
+                // change the value in the text box to something with only one error message
+                await user.clear(textBox);
+                await user.type(textBox, invalidValue1);
+
+                // both error messages are still present
+                await waitFor(() => {
+                    expect(screen.getByText(`Don't say ${invalidValue1}`)).toBeVisible();
+                });
+                expect(screen.getByText(`Don't say ${invalidValue2}`)).toBeVisible();
+
+                // blur the input
+                await user.tab();
+
+                // only one error message remains
+                await waitFor(() => {
+                    expect(screen.getByText(`Don't say ${invalidValue1}`)).toBeVisible();
+                });
+
+                expect(screen.queryByText(`Don't say ${invalidValue2}`)).not.toBeInTheDocument();
+            });
+        });
+    });
+});
+
+const FormWithField = (props: FormFieldProps) => {
+    const [onSubmit] = useState(new Observable());
+
+    const onClick = useCallback(() => {
+        onSubmit.notify();
+    }, [onSubmit]);
+
+    return (<>
+        <FormProvider onSubmit={onSubmit}>
+            <FormField id={props.id} name={props.name} validators={props.validators}/>
+            <button onClick={onClick}>SUBMIT</button>
+        </FormProvider>
+    </>);
+};

--- a/src/components/form/FormField.tsx
+++ b/src/components/form/FormField.tsx
@@ -1,0 +1,62 @@
+import React, { RefObject, useCallback, useContext, useEffect, useRef, useState } from "react";
+import { useValidation, Validator } from "../../hooks/form-validation/useValidation";
+import { FormContext } from "../../contexts/FormContext";
+
+export enum FormFieldType {
+    INPUT,
+    TEXTAREA
+}
+
+export type FormFieldProps = {
+    id: string
+    name: string
+    validators: Validator[]
+    autocomplete?: string
+    inputType?: FormFieldType
+}
+
+export type FormFieldElement = HTMLInputElement | HTMLTextAreaElement;
+
+export const FormField = ({ id, name, validators, autocomplete, inputType = FormFieldType.INPUT }: FormFieldProps) => {
+    const { registerValidation } = useContext(FormContext);
+    const inputRef = useRef<FormFieldElement>(null);
+    const [errorMessages, setErrorMessages] = useState<string[]>([]);
+
+    const errorsElements = errorMessages.map(message => {
+        return <li key={message}>{message}</li>;
+    });
+
+    const validation = useValidation({ validators, inputRef, setErrorMessages });
+
+    useEffect(() => {
+        registerValidation({ validation, inputRef });
+    }, [registerValidation, validation]);
+
+    const onBlur = useCallback(() => {
+        validation();
+    }, [validation]);
+
+    const invalid = errorMessages.length > 0;
+    const errorMessageContainerId = invalid ? `error-message-container-${id}` : "";
+
+    const input = inputType === FormFieldType.INPUT
+        ? <input id={id} name={name} ref={inputRef as RefObject<HTMLInputElement>}
+                 aria-describedby={errorMessageContainerId}
+                 aria-invalid={invalid} aria-errormessage={errorMessageContainerId}
+                 onBlur={onBlur} autoComplete={autocomplete}
+        />
+        : <textarea id={id} name={name} ref={inputRef as RefObject<HTMLTextAreaElement>}
+                    aria-describedby={errorMessageContainerId}
+                    aria-invalid={invalid} aria-errormessage={errorMessageContainerId}
+                    onBlur={onBlur} autoComplete={autocomplete}
+        />;
+
+    return (<>
+        {invalid &&
+            <ul id={errorMessageContainerId}>
+                {errorsElements}
+            </ul>
+        }
+        {input}
+    </>);
+};

--- a/src/contexts/FormContext.test.tsx
+++ b/src/contexts/FormContext.test.tsx
@@ -1,0 +1,110 @@
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
+import { FormContext, FormProvider } from "./FormContext";
+import { render, screen, waitFor } from "@testing-library/react";
+import { ChildrenProps } from "../utilities/children-props";
+import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
+import userEvent from "@testing-library/user-event";
+import { Observable } from "../utilities/observable";
+
+const validValue = "valid";
+const nameLabel = "NAME";
+const colorLabel = "COLOR";
+const cityLabel = "CITY";
+
+describe("Form Context", () => {
+    let user: UserEvent;
+    beforeEach(() => {
+        user = userEvent.setup();
+        render(<TestPageComponent/>);
+    });
+    test("Runs all validations when the onSubmit is triggered", async () => {
+        const submit = screen.getByRole("button", { name: "SUBMIT" });
+        await user.click(submit);
+        await waitFor(() => {
+            expect(screen.getByText(`${nameLabel} input is invalid`)).toBeInTheDocument();
+        });
+        expect(screen.getByText(`${colorLabel} input is invalid`)).toBeInTheDocument();
+        expect(screen.getByText(`${cityLabel} input is invalid`)).toBeInTheDocument();
+    });
+    test("Returns the value to the obervable", async () => {
+        expect(screen.getByText("OBSERVED: false")).toBeVisible();
+
+        const submit = screen.getByRole("button", { name: "SUBMIT" });
+        await user.click(submit);
+
+        await waitFor(() => {
+            expect(screen.getByText("OBSERVED: true")).toBeVisible();
+        });
+    });
+    test("Focuses earliest input that has an error", async () => {
+        const nameInput = screen.getByLabelText(nameLabel);
+        await user.type(nameInput, validValue);
+
+        const colorInput = screen.getByLabelText(colorLabel);
+
+        const submit = screen.getByRole("button", { name: "SUBMIT" });
+        await user.click(submit);
+
+        await waitFor(() => {
+            expect(colorInput).toHaveFocus();
+        });
+    });
+});
+
+const TestFormWithProvider = ({ children }: ChildrenProps) => {
+    const [onSubmitObservable] = useState(new Observable());
+    const [observed, setObserved] = useState("false");
+
+    const onSubmit = useCallback(() => {
+        const observableResult = onSubmitObservable.notify();
+        if (observableResult === true) {
+            setObserved("true");
+        }
+    }, [onSubmitObservable]);
+
+    return (<FormProvider onSubmit={onSubmitObservable}>
+        {children}
+        <span>OBSERVED: {observed}</span>
+        <button onClick={onSubmit}>SUBMIT</button>
+    </FormProvider>);
+};
+
+const TestInputFormConsumer = ({ label }: { label: string }) => {
+    const { registerValidation } = useContext(FormContext);
+    const input = useRef<HTMLInputElement>(null);
+    const [errorMessage, setErrorMessage] = useState("");
+
+    const validation = useCallback(() => {
+        if (input.current!.value === validValue) {
+            setErrorMessage("");
+            return [];
+        }
+
+        const message = `${label} input is invalid`;
+        setErrorMessage(message);
+        return [message];
+    }, [label]);
+
+    useEffect(() => {
+        registerValidation({ validation, inputRef: input });
+    }, [registerValidation, validation]);
+
+    return (<>
+        <label>{label}
+            <input ref={input}/>
+        </label>
+        {errorMessage &&
+            <span>{errorMessage}</span>
+        }
+    </>);
+};
+
+const TestPageComponent = () => {
+    return (<>
+        <TestFormWithProvider>
+            <TestInputFormConsumer label={nameLabel}/>
+            <TestInputFormConsumer label={colorLabel}/>
+            <TestInputFormConsumer label={cityLabel}/>
+        </TestFormWithProvider>
+    </>);
+};

--- a/src/contexts/FormContext.tsx
+++ b/src/contexts/FormContext.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { Field } from "../hooks/form-validation/useValidation";
+import { ChildrenProps } from "../utilities/children-props";
+import { Observable } from "../utilities/observable";
+import { useFocusElement } from "../hooks/useFocusElement";
+
+export type FormContextValue = {
+    registerValidation: (field: Field) => void;
+}
+
+const defaultValue = { registerValidation: () => {} };
+export const FormContext = React.createContext<FormContextValue>(defaultValue);
+
+type FormProviderProps = {
+    onSubmit: Observable
+}
+
+export const FormProvider = ({ onSubmit, children }: FormProviderProps & ChildrenProps) => {
+    const fields = useRef<Field[]>([]);
+
+    const registerValidation = useCallback((field: Field) => {
+        fields.current = [...fields.current, field];
+    }, []);
+
+    const focusElement = useFocusElement();
+
+    const runValidations = useCallback(() => {
+        let invalidFieldFound = false;
+        for (const field of fields.current) {
+            const errors = field.validation();
+            if (errors.length && !invalidFieldFound) {
+                focusElement(field.inputRef);
+                invalidFieldFound = true;
+            }
+        }
+        return invalidFieldFound;
+    }, [focusElement]);
+
+    useEffect(() => {
+        onSubmit.subscribe(runValidations);
+        return () => {
+            onSubmit.unsubscribe();
+        };
+    }, [onSubmit, runValidations]);
+
+    const providerValue: FormContextValue = {
+        registerValidation,
+    };
+    return (
+        <FormContext.Provider value={providerValue}>
+            {children}
+        </FormContext.Provider>
+    );
+};

--- a/src/hooks/form-validation/useValidation.test.tsx
+++ b/src/hooks/form-validation/useValidation.test.tsx
@@ -1,0 +1,80 @@
+import { useValidation, Validator } from "./useValidation";
+import { render, screen, waitFor } from "@testing-library/react";
+import React, { useRef, useState } from "react";
+import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
+import userEvent from "@testing-library/user-event";
+
+describe(useValidation.name, () => {
+    let user: UserEvent;
+    beforeEach(() => {
+        user = userEvent.setup();
+    });
+    test("returns a validation that runs all validators passed in", async () => {
+        const validators = [
+            jest.fn().mockReturnValue("name is invalid"),
+            jest.fn().mockReturnValue("email is invalid"),
+            jest.fn().mockReturnValue("color is invalid"),
+        ];
+
+        render(<ValidatingComponent validators={validators} initialRefValue={{ value: "invalid input value" }}/>);
+
+        await user.click(screen.getByRole("button"));
+
+        await waitFor(() => {
+            expect(screen.getByText("name is invalid")).toBeInTheDocument();
+        });
+        expect(screen.getByText("email is invalid")).toBeInTheDocument();
+        expect(screen.getByText("color is invalid")).toBeInTheDocument();
+    });
+
+    test("does nothing if there is no current value to the input ref", async () => {
+        const validator = jest.fn().mockReturnValue("should not be called");
+
+        render(<ValidatingComponent validators={[validator]} initialRefValue={null}/>);
+
+        await user.click(screen.getByRole("button"));
+
+        expect(validator).toHaveBeenCalledTimes(0);
+    });
+
+    const emptyValueTestCases = [
+        null,
+        undefined,
+    ];
+    emptyValueTestCases.forEach(testCase => {
+        test(`does nothing if the input ref's value is ${testCase}`, async () => {
+            const validator = jest.fn().mockReturnValue("should not be called");
+
+            render(<ValidatingComponent validators={[validator]}
+                                        initialRefValue={{ value: testCase }}/>);
+
+            await user.click(screen.getByRole("button"));
+
+            expect(validator).toHaveBeenCalledTimes(0);
+        });
+    });
+});
+
+type ValidatingComponentProps = {
+    validators: Validator[]
+    initialRefValue: { value: string | null | undefined } | null
+}
+
+const ValidatingComponent = ({ validators, initialRefValue }: ValidatingComponentProps) => {
+    const inputRef = useRef<HTMLInputElement>(initialRefValue as HTMLInputElement);
+    const [errorMessages, setErrorMessages] = useState([""]);
+    const validation = useValidation({ validators, inputRef, setErrorMessages });
+
+    const errorsElement = errorMessages.map(message => {
+        return <span key={message}>{message}</span>;
+    });
+
+    const onClick = () => {
+        validation();
+    };
+
+    return (<>
+        {errorsElement}
+        <button onClick={onClick}>SUBMIT</button>
+    </>);
+};

--- a/src/hooks/form-validation/useValidation.ts
+++ b/src/hooks/form-validation/useValidation.ts
@@ -1,0 +1,34 @@
+import { Dispatch, RefObject, SetStateAction, useCallback } from "react";
+import { FormFieldElement } from "../../components/form/FormField";
+
+export type Validator = (value: string) => string;
+export type Validation = () => string[];
+export type Field = {
+    inputRef: RefObject<FormFieldElement>
+    validation: Validation,
+}
+
+type UseValidationInput = {
+    validators: Validator[]
+    inputRef: RefObject<FormFieldElement>
+    setErrorMessages: Dispatch<SetStateAction<string[]>>
+}
+
+export const useValidation = ({ validators, inputRef, setErrorMessages }: UseValidationInput): Validation => {
+    return useCallback(() => {
+        if (inputRef.current === null || inputRef.current.value === null || inputRef.current.value === undefined) {
+            return [];
+        }
+
+        let errorMessages: string [] = [];
+        for (const validator of validators) {
+            const message = validator(inputRef.current.value);
+            if (message) {
+                errorMessages.push(message);
+            }
+        }
+
+        setErrorMessages(errorMessages);
+        return errorMessages;
+    }, [validators, inputRef, setErrorMessages]);
+};

--- a/src/hooks/form-validation/useValidations.ts
+++ b/src/hooks/form-validation/useValidations.ts
@@ -1,1 +1,0 @@
-export type Validator = (value: string) => string

--- a/src/hooks/form-validation/validateEmail.ts
+++ b/src/hooks/form-validation/validateEmail.ts
@@ -1,4 +1,4 @@
-import { Validator } from "./useValidations";
+import { Validator } from "./useValidation";
 
 export const INVALID_EMAIL_MESSAGE = "This is not a valid email address. It must have an at symbol (@) and a period (.) like this: abc@xyz.com";
 

--- a/src/hooks/form-validation/validatePhone.ts
+++ b/src/hooks/form-validation/validatePhone.ts
@@ -1,4 +1,4 @@
-import { Validator } from "./useValidations";
+import { Validator } from "./useValidation";
 
 export const INVALID_PHONE_MESSAGE = "This is not a valid phone number. Make sure it contains 7 or 10 digits excluding a 1 at the beginning";
 

--- a/src/hooks/form-validation/validateRequired.ts
+++ b/src/hooks/form-validation/validateRequired.ts
@@ -1,4 +1,4 @@
-import { Validator } from "./useValidations";
+import { Validator } from "./useValidation";
 
 export const MISSING_REQUIRED_MESSAGE = "You must enter something in this field";
 

--- a/src/hooks/useFocusElement.test.tsx
+++ b/src/hooks/useFocusElement.test.tsx
@@ -1,0 +1,40 @@
+import React, { useCallback, useRef } from "react";
+import { useFocusElement } from "./useFocusElement";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(useFocusElement.name, () => {
+    test("focuses element within 100 milliseconds of process.env.FOCUS_TIMEOUT", async () => {
+        const user = userEvent.setup();
+        render(<FocusingComponent/>);
+
+        await user.click(screen.getByRole("button"));
+
+        const start = new Date();
+
+        await waitFor(() => {
+            expect(screen.getByRole("textbox")).toHaveFocus();
+        });
+
+        const end = new Date();
+
+        const duration = end.getTime() - start.getTime();
+
+        expect(duration - 100).toBeLessThan(parseInt(process.env.FOCUS_TIMEOUT!));
+        expect(duration + 100).toBeGreaterThan(parseInt(process.env.FOCUS_TIMEOUT!));
+    });
+});
+
+const FocusingComponent = () => {
+    const elementToFocus = useRef(null);
+    const focusElement = useFocusElement();
+
+    const onClick = useCallback(() => {
+        focusElement(elementToFocus);
+    }, [focusElement]);
+
+    return (<>
+        <input ref={elementToFocus}/>
+        <button onClick={onClick}>FOCUS</button>
+    </>);
+};

--- a/src/hooks/useFocusElement.tsx
+++ b/src/hooks/useFocusElement.tsx
@@ -1,0 +1,11 @@
+import { RefObject, useCallback } from "react";
+
+type FocusElement = (element: RefObject<HTMLElement>) => void;
+
+export const useFocusElement = (): FocusElement => {
+    return useCallback((element) => {
+        setTimeout(() => {
+            element.current?.focus();
+        }, parseInt(process.env.FOCUS_TIMEOUT ?? "2000"));
+    }, []);
+};

--- a/src/pages/accessibility-issues/AccessibilityIssues.test.tsx
+++ b/src/pages/accessibility-issues/AccessibilityIssues.test.tsx
@@ -10,6 +10,9 @@ import { stubAccessibilityFormData } from "../../../test/test-factories";
 import { axe } from "jest-axe";
 import { SERVER_ENDPOINTS } from "../../utilities/server-endpoints";
 import { buildPostResolver } from "../../mock-server/resolvers/post-resolver";
+import { INVALID_EMAIL_MESSAGE } from "../../hooks/form-validation/validateEmail";
+import { INVALID_PHONE_MESSAGE } from "../../hooks/form-validation/validatePhone";
+import { MISSING_REQUIRED_MESSAGE } from "../../hooks/form-validation/validateRequired";
 import { Container } from "react-dom";
 
 describe(`${AccessibilityIssues.name} form`, () => {
@@ -22,6 +25,7 @@ describe(`${AccessibilityIssues.name} form`, () => {
 
     beforeEach(() => {
         user = userEvent.setup();
+        capturedFormData = null as unknown as AccessibilityFormData;
 
         const resolver = buildPostResolver<AccessibilityFormData>({
             captor: (requestBody) => capturedFormData = requestBody,
@@ -48,42 +52,85 @@ describe(`${AccessibilityIssues.name} form`, () => {
         expect(screen.getByLabelText(formLabelText)).toBe(form);
     });
 
-    test("sends form contents to the server", async () => {
-        const nameInput: HTMLInputElement = within(form).getByRole("textbox", { name: "Your Name (optional)" });
-        const emailInput: HTMLInputElement = within(form).getByRole("textbox", { name: "Your email (optional)" });
-        const phoneInput: HTMLInputElement = within(form).getByRole("textbox", { name: "Your phone number (optional)" });
-        const descriptionInput: HTMLTextAreaElement = within(form).getByRole("textbox", { name: "What do you want to tell us? (required)" });
-        const submit: HTMLButtonElement = within(form).getByRole("button", { name: "Submit" });
+    describe("when the form data is valid", () => {
+        test("sends form contents to the server", async () => {
+            const nameInput: HTMLInputElement = within(form).getByRole("textbox", { name: "Your Name (optional)" });
+            const emailInput: HTMLInputElement = within(form).getByRole("textbox", { name: "Your email (optional)" });
+            const phoneInput: HTMLInputElement = within(form).getByRole("textbox", { name: "Your phone number (optional)" });
+            const descriptionInput: HTMLTextAreaElement = within(form).getByRole("textbox", { name: "What do you want to tell us? (required)" });
+            const submit: HTMLButtonElement = within(form).getByRole("button", { name: "Submit" });
 
-        await user.tab();
-        expect(nameInput).toHaveFocus();
-        const name = "Linda Cardellini";
-        await user.keyboard(name);
+            await user.tab();
+            expect(nameInput).toHaveFocus();
+            const name = "Linda Cardellini";
+            await user.keyboard(name);
 
-        await user.tab();
-        expect(emailInput).toHaveFocus();
-        const email = "lcardellini@example.com";
-        await user.keyboard(email);
+            await user.tab();
+            expect(emailInput).toHaveFocus();
+            const email = "lcardellini@example.com";
+            await user.keyboard(email);
 
-        await user.tab();
-        expect(phoneInput).toHaveFocus();
-        const phone = "9999999999";
-        await user.keyboard(phone);
+            await user.tab();
+            expect(phoneInput).toHaveFocus();
+            const phone = "9999999999";
+            await user.keyboard(phone);
 
-        await user.tab();
-        expect(descriptionInput).toHaveFocus();
-        const description = "There was an input that didn't have a label";
-        await user.keyboard(description);
+            await user.tab();
+            expect(descriptionInput).toHaveFocus();
+            const description = "There was an input that didn't have a label";
+            await user.keyboard(description);
 
-        await user.tab();
-        expect(submit).toHaveFocus();
+            await user.tab();
+            expect(submit).toHaveFocus();
 
-        await user.keyboard("{Enter}");
+            await user.keyboard("{Enter}");
 
-        expect(capturedFormData).toEqual(stubAccessibilityFormData({ name, email, phone, description }));
+            expect(capturedFormData).toEqual(stubAccessibilityFormData({ name, email, phone, description }));
 
-        await waitFor(() => {
-            expect(screen.getByText(successMessage)).toBeInTheDocument();
+            await waitFor(() => {
+                expect(screen.getByText(successMessage)).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe("when the form data is invalid", () => {
+        let emailInput: HTMLInputElement;
+        let phoneInput: HTMLInputElement;
+        let descriptionInput: HTMLTextAreaElement;
+        let submit: HTMLButtonElement;
+        beforeEach(async () => {
+            emailInput = within(form).getByRole("textbox", { name: "Your email (optional)" });
+            phoneInput = within(form).getByRole("textbox", { name: "Your phone number (optional)" });
+            descriptionInput = within(form).getByRole("textbox", { name: "What do you want to tell us? (required)" });
+            submit = within(form).getByRole("button", { name: "Submit" });
+
+            await user.type(descriptionInput, "non-empty value");
+        });
+        test("shows error message for email", async () => {
+            await user.type(emailInput, "invalid@email");
+            await user.click(submit);
+            await waitFor(() => {
+                expect(screen.getByText(INVALID_EMAIL_MESSAGE)).toBeVisible();
+            });
+        });
+        test("shows error message for phone number", async () => {
+            await user.type(phoneInput, "1");
+            await user.click(submit);
+            await waitFor(() => {
+                expect(screen.getByText(INVALID_PHONE_MESSAGE)).toBeVisible();
+            });
+        });
+        test("shows error message for required description", async () => {
+            await user.clear(descriptionInput);
+            await user.click(submit);
+            await waitFor(() => {
+                expect(screen.getByText(MISSING_REQUIRED_MESSAGE)).toBeVisible();
+            });
+        });
+        test("doesn't submit the form", async () => {
+            await user.clear(descriptionInput);
+            await user.click(submit);
+            expect(capturedFormData).toBeNull();
         });
     });
 });

--- a/src/pages/accessibility-issues/AccessibilityIssues.tsx
+++ b/src/pages/accessibility-issues/AccessibilityIssues.tsx
@@ -2,6 +2,10 @@ import React, { useState } from "react";
 import "../Pages.css";
 import { Form } from "../../components/form/Form";
 import { SERVER_ENDPOINTS } from "../../utilities/server-endpoints";
+import { FormField } from "../../components/form/FormField";
+import { validateEmail } from "../../hooks/form-validation/validateEmail";
+import { validatePhone } from "../../hooks/form-validation/validatePhone";
+import { validateRequired } from "../../hooks/form-validation/validateRequired";
 
 export type AccessibilityFormData = {
     name?: string
@@ -21,11 +25,11 @@ export const AccessibilityIssues = () => {
                 <label htmlFor={"name"}>Your Name (optional)</label>
                 <input id={"name"} autoComplete={"name"} name={"name"}/>
                 <label htmlFor={"email"}>Your email (optional)</label>
-                <input id={"email"} autoComplete={"email"} name={"email"}/>
+                <FormField id={"email"} name={"email"} validators={[validateEmail]}/>
                 <label htmlFor={"phone"}>Your phone number (optional)</label>
-                <input id={"phone"} autoComplete={"tel"} name={"phone"}/>
+                <FormField id={"phone"} name={"phone"} validators={[validatePhone]}/>
                 <label htmlFor={"description"}>What do you want to tell us? (required)</label>
-                <textarea id={"description"} name={"description"}/>
+                <FormField id={"description"} name={"description"} validators={[validateRequired]}/>
             </Form>
         </div>
     );

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -8,6 +8,7 @@ import { setupTestingServer } from "./mock-server/setup-testing-server";
 import { toHaveNoViolations } from "jest-axe";
 
 process.env.REACT_APP_API = "test";
+process.env.FOCUS_TIMEOUT = "10";
 
 setupTestingServer();
 

--- a/src/utilities/observable.test.ts
+++ b/src/utilities/observable.test.ts
@@ -1,0 +1,56 @@
+import { Observable } from "./observable";
+
+describe(Observable.name, () => {
+    test("notifies subscriber and returns value", () => {
+        const returnValue = 1;
+        const observable = new Observable();
+
+        let notified = false;
+
+        observable.subscribe(() => {
+            notified = true;
+            return returnValue;
+        });
+
+        const result = observable.notify();
+
+        expect(notified).toBe(true);
+        expect(result).toBe(1);
+    });
+    test("unsubscribe removes subscriber", () => {
+        const observable = new Observable();
+
+        let notified = false;
+
+        const subscriber = () => {
+            notified = true;
+        };
+        observable.subscribe(subscriber);
+        observable.unsubscribe();
+
+        const result = observable.notify();
+
+        expect(notified).toBe(false);
+        expect(result).toBeUndefined();
+    });
+    test("throws error if subscribed with existing subscriber", () => {
+        const observable = new Observable();
+
+        const subscriber = () => {
+            console.log("hello");
+        };
+        observable.subscribe(subscriber);
+        expect(() => {
+            observable.subscribe(subscriber);
+        }).toThrow(new Error("Observable already has a subscriber"));
+    });
+    test("does nothing if unsubscribed without a subscriber", () => {
+        const observable = new Observable();
+
+        observable.unsubscribe();
+
+        expect(() => {
+            observable.unsubscribe();
+        }).not.toThrow();
+    });
+});

--- a/src/utilities/observable.ts
+++ b/src/utilities/observable.ts
@@ -1,0 +1,26 @@
+type Subscriber = () => any;
+
+export class Observable {
+    private subscriber: Subscriber;
+
+    constructor() {
+        this.subscriber = this.noOp;
+    }
+
+    subscribe(subscriber: Subscriber) {
+        if (this.subscriber !== this.noOp) {
+            throw new Error("Observable already has a subscriber");
+        }
+        this.subscriber = subscriber;
+    }
+
+    unsubscribe() {
+        this.subscriber = this.noOp;
+    }
+
+    notify() {
+        return this.subscriber();
+    }
+
+    private readonly noOp = () => {};
+}


### PR DESCRIPTION
Treble 39 - Remove unused types from package file

Treble 39 - Add a context that a form can provide that runs all inputs' validations when the form is submitted.

Treble 39 - Make validations on the Form Provider a ref to avoid rerendering if they change.

Treble 39 - Form context focuses the earliest field that has an invalid value on form submit

Treble 39 - Add hook to focus element after a 2-second delay, use it to focus the first invalid field when a form is submitted.

Treble 39 - rename validation hook

Treble 39 - Add hook to create a validation from a list of validators and an input ref

Treble 39 - WIP adding form field

Treble 39 - Form Field shows error message when validation runs and its value is invalid

Treble 39 - show all error messages in a list in the Form Field

Treble 39 - Form field reruns validation on blur

Treble 39 - Form provides the form context

updated observable to return a boolean indicating whether invalid fields were found.

RHEI - Use validating form fields in the Accessibility Issues page.

RHEI - Pass autocomplete to form input element, allow creating a textarea in the FormField component.