### PR TITLE
Add missing dependency to form submit callback

### DIFF
--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -66,7 +66,7 @@ export const Form = ({ children, ariaLabelledBy, submitEndpoint, successMessage 
             });
         }
 
-    }, [postFormData, onSubmitObservable]);
+    }, [onSubmitObservable, postFormData, onClearObservable]);
 
     return (<div className={"form-container"}>
             {showSuccessMessage &&

--- a/src/components/form/FormField.tsx
+++ b/src/components/form/FormField.tsx
@@ -1,5 +1,5 @@
 import React, { RefObject, useCallback, useContext, useEffect, useRef, useState } from "react";
-import { useValidation, Validator, Validation } from "../../hooks/form-validation/useValidation";
+import { useValidation, Validator } from "../../hooks/form-validation/useValidation";
 import { FormContext } from "../../contexts/FormContext";
 import { useLocalStorage } from "../../hooks/useLocalStorage";
 
@@ -19,7 +19,14 @@ export type FormFieldProps = {
 
 export type FormFieldElement = HTMLInputElement | HTMLTextAreaElement;
 
-export const FormField = ({ id, name, validator, autoComplete, pageIdentifier, inputType = FormFieldType.INPUT }: FormFieldProps) => {
+export const FormField = ({
+                              id,
+                              name,
+                              validator,
+                              autoComplete,
+                              pageIdentifier,
+                              inputType = FormFieldType.INPUT
+                          }: FormFieldProps) => {
     const { registerField } = useContext(FormContext);
     const inputRef = useRef<FormFieldElement>(null);
     const [errorMessage, setErrorMessage] = useState<string>("");
@@ -31,18 +38,17 @@ export const FormField = ({ id, name, validator, autoComplete, pageIdentifier, i
             inputRef.current.value = "";
             clearStorage();
         }
-    }, []);
+    }, [clearStorage]);
 
     useEffect(() => {
         registerField({ validation, inputRef, clear });
-    }, [registerField, validation]);
-    
+    }, [clear, registerField, validation]);
+
     useEffect(() => {
-        if (inputRef.current)
-        {
+        if (inputRef.current) {
             inputRef.current.value = window.localStorage.getItem(`${pageIdentifier}-${id}`) ?? "";
         }
-    }, []);
+    }, [id, pageIdentifier]);
 
     const onBlur = useCallback(() => {
         if (errorMessage !== "") {
@@ -52,7 +58,7 @@ export const FormField = ({ id, name, validator, autoComplete, pageIdentifier, i
 
     const onChange = useCallback((event) => {
         save(event.target.value);
-    }, []);
+    }, [save]);
 
     const invalid = errorMessage !== "";
     const errorMessageId = invalid ? `form-error-message-for-${id}` : "";

--- a/src/hooks/useLocalStorage.tsx
+++ b/src/hooks/useLocalStorage.tsx
@@ -1,18 +1,16 @@
-import { useState, useCallback } from "react";
+import { useCallback, useState } from "react";
 
-export const useLocalStorage = (storageKey : string) => {
-    const [key] = useState(storageKey);
-
-    const [currentValue, setCurrentValue] = useState(window.localStorage.getItem(key) ?? "");
+export const useLocalStorage = (storageKey: string) => {
+    const [currentValue, setCurrentValue] = useState(window.localStorage.getItem(storageKey) ?? "");
 
     const save = useCallback((input: string) => {
-        window.localStorage.setItem(key, input);
+        window.localStorage.setItem(storageKey, input);
         setCurrentValue(input);
-    }, [key]);
+    }, [storageKey]);
 
     const clearStorage = useCallback(() => {
         window.localStorage.removeItem(storageKey);
-    }, [key]);
+    }, [storageKey]);
 
     return { save, currentValue, clearStorage };
 };


### PR DESCRIPTION
@HelenHagos We left some dependencies off of hooks when we were updating them to work with the local storage stuff. Most of the fixes in this PR are for that.

One other change I made was to remove the state storing the key in `useLocalStorage` because we were using it inconsistently. Putting it in a state and never updating it would cause bugs if the component passing it in every changed it, so I got rid of that state and used the key as it was passed in.