### PR TITLE
Add icon indicator of current page to the current page link

### DIFF
--- a/src/components/navigation/AppLink.test.tsx
+++ b/src/components/navigation/AppLink.test.tsx
@@ -16,11 +16,16 @@ describe(AppLink.name, () => {
         );
     });
     test("assigns class and aria-current for matched route", () => {
-        let activeLink = screen.getByRole("link", { name: activeLinkText, current: "page" });
+        const activeLink = screen.getByRole("link", { name: activeLinkText, current: "page" });
         expect(activeLink.className).toContain("matched-link");
     });
+    test("shows icon for matched route", () => {
+        const icon = screen.getByRole("img", { hidden: true });
+        expect(icon).toBeVisible();
+        expect(icon.getAttribute("src")).toContain("current-page.svg");
+    });
     test("doesn't assign class and aria-current for unmatched route", () => {
-        let inactiveLink = screen.getByRole("link", { name: inactiveLinkText, current: undefined });
+        const inactiveLink = screen.getByRole("link", { name: inactiveLinkText, current: undefined });
         expect(inactiveLink.className).not.toContain("matched-link");
     });
 });

--- a/src/components/navigation/AppLink.tsx
+++ b/src/components/navigation/AppLink.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Link, LinkProps, PathMatch, useMatch, useResolvedPath } from "react-router-dom";
+import { CurrentPageIcon } from "./CurrentPageIcon";
 
 export const AppLink = (props: Omit<LinkProps, "reloadDocument">) => {
     const resolved = useResolvedPath(props.to);
@@ -8,9 +9,12 @@ export const AppLink = (props: Omit<LinkProps, "reloadDocument">) => {
         end: true,
     });
 
-    return (<Link
-        {...props}
-        className={match ? `${props.className} matched-link` : props.className}
-        aria-current={match ? "page" : undefined}
-    />);
+    return (<>
+        {match && <CurrentPageIcon/>}
+        <Link
+            {...props}
+            className={match ? `${props.className} matched-link` : props.className}
+            aria-current={match ? "page" : undefined}
+        />
+    </>);
 };

--- a/src/components/navigation/CurrentPageIcon.tsx
+++ b/src/components/navigation/CurrentPageIcon.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import icon from "./current-page.svg";
+
+export const CurrentPageIcon = () => {
+    return (
+        <img alt={"current page icon"} aria-hidden={true} className={"current-page-icon"} src={icon}/>
+    );
+};

--- a/src/components/navigation/Navigation.css
+++ b/src/components/navigation/Navigation.css
@@ -58,6 +58,11 @@ nav {
 
 .matched-link {
     color: #c39738;
+    padding-left: 0;
+}
+
+.current-page-icon {
+
 }
 
 @media (min-width: 961px) {

--- a/src/components/navigation/current-page.svg
+++ b/src/components/navigation/current-page.svg
@@ -1,0 +1,9 @@
+<svg width="16px" height="16px" viewBox="0 -2 12 12" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <g stroke="none" stroke-width="1" fill-rule="evenodd">
+        <g transform="translate(-427.000000, -3765.000000)" fill="#c39738">
+            <g transform="translate(56.000000, 160.000000)">
+                <polygon points="371 3605 371 3613 378 3609"/>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
[Accessibility Issue: Link showing current page is conveyed by color alone](https://trello.com/c/LSucHJOJ/66-accessibility-issue-link-showing-current-page-is-conveyed-by-color-alone)

This image is decorative so it's OK that it has `aria-hidden`. A screen reader will read that this link is for the current page because of the `aria-current` attribute.