### PR TITLE
Properly handle exception thrown trying to make requests to the API

### DIFF
--- a/src/hooks/fetch/useGet.test.tsx
+++ b/src/hooks/fetch/useGet.test.tsx
@@ -117,9 +117,10 @@ describe(useGET.name, () => {
                 await user.click(button);
             });
 
-            test("does not throw an error or show one on the screen", async () => {
-                rejectPromise(new DOMException("Abortedd"));
-                expect(await screen.findByText("Something went wrong.")).toBeInTheDocument();
+            test("shows an error notification", async () => {
+                const exception = new DOMException("Abortedd");
+                rejectPromise(exception);
+                expect(await screen.findByText(`Something went wrong. ${exception}`)).toBeInTheDocument();
             });
 
             test("stops loading", async () => {

--- a/src/hooks/fetch/useGet.tsx
+++ b/src/hooks/fetch/useGet.tsx
@@ -41,10 +41,11 @@ export function useGET<T>(endpoint: string): GetFunction<T> {
             const errorMessage = body?.error ?? DEFAULT_ERROR_MESSAGE;
 
             responseCallback(ok, body as T, errorMessage);
-        } catch {
-            responseCallback(false, undefined as unknown as T, "Something went wrong.");
+        } catch (error) {
+            responseCallback(false, undefined as unknown as T, `Something went wrong. ${error}`);
         } finally {
             finishLoading();
         }
+
     }, [endpoint, finishLoading, startLoading]);
 }

--- a/src/hooks/fetch/usePost.test.tsx
+++ b/src/hooks/fetch/usePost.test.tsx
@@ -97,11 +97,10 @@ describe(usePOST.name, () => {
                 await user.click(button);
             });
 
-            test("does not throw an error or show one on the screen", async () => {
-                abortRequest(new DOMException("Abortedd"));
-                expect(screen.queryByText(ryan.name)).not.toBeInTheDocument();
-                expect(screen.queryByText("There was a successful, empty response")).not.toBeInTheDocument();
-                expect(screen.queryByTestId("error-container")).not.toBeInTheDocument();
+            test("shows an error notification", async () => {
+                const exception = new DOMException("Abortedd");
+                abortRequest(exception);
+                expect(await screen.findByText(`Something went wrong submitting your message. ${exception}`)).toBeInTheDocument();
             });
         });
 

--- a/src/hooks/fetch/usePost.tsx
+++ b/src/hooks/fetch/usePost.tsx
@@ -29,7 +29,9 @@ export function usePOST<ResponseBody>(endpoint: string): PostFunction<ResponseBo
             const errorMessage = body?.error ?? DEFAULT_ERROR_MESSAGE;
 
             responseCallback(response.ok, body as ResponseBody, errorMessage);
-        } catch {}
+        } catch (error) {
+            responseCallback(false, undefined as unknown as ResponseBody, `Something went wrong submitting your message. ${error}`);
+        }
 
     }, [endpoint]);
 }


### PR DESCRIPTION
[Bug: Contact forms hang when the API is unavailable](https://trello.com/c/OXUs4xXX/58-bug-contact-forms-hang-when-the-api-is-unavailable)

To test this, you need to deploy to dev and put the dev server into maintenance mode.