### PR TITLE
Fix regression: menu button not focused properly when closed with escape

### DIFF
--- a/src/components/navigation/NavMenu.test.tsx
+++ b/src/components/navigation/NavMenu.test.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { MemoryRouter } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 import { NavLinks } from "./NavLinks";
-import { KEYS } from "../../../test/user-event-keys";
+import { USER_EVENT_KEYS_FOR_TESTING_ONLY } from "../../../test/user-event-keys";
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 
 describe(NavMenu.name, () => {
@@ -72,42 +72,28 @@ describe(NavMenu.name, () => {
             expect(document.body).toHaveFocus();
         });
         test("can open and close the menu with the space bar", async () => {
-            await user.keyboard(KEYS.spaceBar);
+            await user.keyboard(USER_EVENT_KEYS_FOR_TESTING_ONLY.spaceBar);
             expect(screen.getByRole("list")).toBeVisible();
 
-            await user.keyboard(KEYS.spaceBar);
+            await user.keyboard(USER_EVENT_KEYS_FOR_TESTING_ONLY.spaceBar);
             expect(screen.queryByRole("list")).toBeNull();
         });
         test("can open and close the menu with the enter key", async () => {
-            await user.keyboard(KEYS.enter);
+            await user.keyboard(USER_EVENT_KEYS_FOR_TESTING_ONLY.enter);
             expect(screen.getByRole("list")).toBeVisible();
 
-            await user.keyboard(KEYS.enter);
+            await user.keyboard(USER_EVENT_KEYS_FOR_TESTING_ONLY.enter);
             expect(screen.queryByRole("list")).toBeNull();
         });
         describe("when the menu is open", () => {
             let links: HTMLAnchorElement[];
             beforeEach(async () => {
-                await user.keyboard(KEYS.spaceBar);
+                await user.keyboard(USER_EVENT_KEYS_FOR_TESTING_ONLY.spaceBar);
                 linkList = screen.getByRole("list") as HTMLUListElement;
                 links = within(linkList).getAllByRole("link");
             });
             test("should show child links", () => {
                 expect(links.length).toBeGreaterThan(0);
-            });
-            test("can close the menu with the Escape key", async () => {
-                await user.keyboard(KEYS.escape);
-                expect(linkList).not.toBeVisible();
-                expect(menuButton).toHaveFocus();
-            });
-            test("can close the menu with the Escape key when focus is outside the menu", async () => {
-                const elementOutsideMenu = screen.getByText("focus me");
-                elementOutsideMenu.focus();
-
-                await user.keyboard(KEYS.escape);
-                
-                expect(linkList).not.toBeVisible();
-                expect(elementOutsideMenu).toHaveFocus();
             });
             test("can navigate links with the tab key NO KEYBOARD TRAP", async () => {
                 await user.tab();
@@ -135,8 +121,8 @@ describe(NavMenu.name, () => {
                 expect(document.body).toHaveFocus();
             });
             const downCases = [
-                KEYS.arrows.down,
-                KEYS.arrows.right,
+                USER_EVENT_KEYS_FOR_TESTING_ONLY.arrows.down,
+                USER_EVENT_KEYS_FOR_TESTING_ONLY.arrows.right,
             ];
             downCases.forEach(key => {
                 test(`can navigate links down with the arrow keys - ${key}`, async () => {
@@ -151,8 +137,8 @@ describe(NavMenu.name, () => {
                 });
             });
             const upCases = [
-                KEYS.arrows.up,
-                KEYS.arrows.left,
+                USER_EVENT_KEYS_FOR_TESTING_ONLY.arrows.up,
+                USER_EVENT_KEYS_FOR_TESTING_ONLY.arrows.left,
             ];
             upCases.forEach(key => {
                 test(`can navigate links up with the arrow keys - ${key}`, async () => {
@@ -166,12 +152,45 @@ describe(NavMenu.name, () => {
                     expect(menuButton).toHaveFocus();
                 });
             });
+            describe("when focus is outside the menu", () => {
+                test("can close the menu with the Escape key when focus is outside the menu", async () => {
+                    const elementOutsideMenu = screen.getByText("focus me");
+                    elementOutsideMenu.focus();
+
+                    await user.keyboard(USER_EVENT_KEYS_FOR_TESTING_ONLY.escape);
+
+                    expect(linkList).not.toBeVisible();
+                    expect(elementOutsideMenu).toHaveFocus();
+                });
+            });
             describe("and a link is focused", () => {
+                let globalKeydownHandler: (this: HTMLElement, ev: KeyboardEvent) => any;
                 beforeEach(async () => {
+                    globalKeydownHandler = (event) => {
+                        if (event.key === "Escape") {
+                            const failToFocusErrorMessage = `Document body keydown handler ran when it should not. 
+                            The menu handler should handle the escape keypress and stop propagation 
+                            when an element in the menu container has focus. 
+                            This allows this test to fail when the menu button would not get focus 
+                            on menu close when it's supposed to. See the comment from Ryan on this story: 
+                            https://trello.com/c/PQ2n4vC6/64-escape-closes-the-nav-menu-no-matter-what-element-is-focused
+                            `.replace(/^\s*/gm, "");
+
+                            throw new Error(failToFocusErrorMessage);
+                        }
+                    };
+
+                    document.body.addEventListener("keydown", globalKeydownHandler);
                     await user.tab();
                 });
+
+                afterEach(() => {
+                    document.body.removeEventListener("keydown", globalKeydownHandler);
+                });
+
                 test("can close the menu with the Escape key", async () => {
-                    await user.keyboard(KEYS.escape);
+                    expect(links[0]).toHaveFocus();
+                    await user.keyboard(USER_EVENT_KEYS_FOR_TESTING_ONLY.escape);
                     expect(linkList).not.toBeVisible();
                     expect(menuButton).toHaveFocus();
                 });

--- a/test/user-event-keys.ts
+++ b/test/user-event-keys.ts
@@ -1,4 +1,4 @@
-export const KEYS = {
+export const USER_EVENT_KEYS_FOR_TESTING_ONLY = {
     arrows: {
         down: "{ArrowDown}",
         left: "{ArrowLeft}",


### PR DESCRIPTION
Fix browser-only problem where menu button isn't focused when closed with escape when menu item is focused