### PR TITLE
Remove Unused Businesses and Categories pages

### DIFF
--- a/src/components/navigation/NavLinks.test.tsx
+++ b/src/components/navigation/NavLinks.test.tsx
@@ -31,14 +31,6 @@ describe(NavLinks.name, () => {
         const link: HTMLAnchorElement = screen.getByRole("link", { name: LINK_TEXT.annArborOrdinance });
         expect(link.href).toContain(PAGE_ENDPOINTS.annArborOrdinance);
     });
-    test("has a link to the all businesses page", () => {
-        const link: HTMLAnchorElement = screen.getByRole("link", { name: LINK_TEXT.businesses });
-        expect(link.href).toContain(PAGE_ENDPOINTS.businesses);
-    });
-    test("has a link to the categories page", () => {
-        const link: HTMLAnchorElement = screen.getByRole("link", { name: LINK_TEXT.categories });
-        expect(link.href).toContain(PAGE_ENDPOINTS.categories);
-    });
     test("has a link to the contact us page", () => {
         const link: HTMLAnchorElement = screen.getByRole("link", { name: "contact us" });
         expect(link.href).toContain(PAGE_ENDPOINTS.contactUs);

--- a/src/components/navigation/NavLinks.tsx
+++ b/src/components/navigation/NavLinks.tsx
@@ -25,16 +25,6 @@ export const NavLinks = () => {
             </AppLink>
         </li>
         <li className={"nav-list-item"}>
-            <AppLink to={PAGE_ENDPOINTS.businesses} className={"nav-link light-focus-outline"}>
-                {LINK_TEXT.businesses}
-            </AppLink>
-        </li>
-        <li className={"nav-list-item"}>
-            <AppLink to={PAGE_ENDPOINTS.categories} className={"nav-link light-focus-outline"}>
-                {LINK_TEXT.categories}
-            </AppLink>
-        </li>
-        <li className={"nav-list-item"}>
             <AppLink to={PAGE_ENDPOINTS.contactUs} className={"nav-link light-focus-outline"} aria-label={"contact us"}>
                 {LINK_TEXT.contactUs}
             </AppLink>

--- a/src/layout/RouterOutlet.test.tsx
+++ b/src/layout/RouterOutlet.test.tsx
@@ -5,10 +5,8 @@ import { MemoryRouter } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
 import { UserEvent } from "@testing-library/user-event/dist/types/setup/setup";
 import { DOCUMENT_TITLE_SUFFIX } from "../pages/Page";
-import { BUSINESSES_PAGE_HEADING } from "../pages/businesses/Businesses";
 import { CONTACT_PAGE_HEADING } from "../pages/contact-us/ContactUs";
 import { ACCESSIBILITY_PAGE_HEADING } from "../pages/accessibility-issues/AccessibilityIssues";
-import { CATEGORIES_PAGE_HEADING } from "../pages/categories/Categories";
 import { DocumentStateContext } from "../contexts/DocumentStateContext";
 import { AppLink } from "../components/navigation/AppLink";
 import { asyncTimeout } from "../../test/async-timeout";
@@ -60,44 +58,6 @@ describe(RouterOutlet.name, () => {
             });
             test("the document title is correct", () => {
                 expect(document.title).toEqual(`${ORDINANCE_PAGE_HEADING}${DOCUMENT_TITLE_SUFFIX}`);
-            });
-            test("the main heading is focused", async () => {
-                await waitFor(() => {
-                    expect(h1).toHaveFocus();
-                });
-            });
-        });
-
-        describe("Categories", () => {
-            beforeEach(async () => {
-                await user.click(screen.getByRole("link", { name: LINK_TEXT.categories }));
-                h1 = await screen.findByRole("heading", { level: 1, name: CATEGORIES_PAGE_HEADING });
-                await screen.findByText("Banks"); // wait for Categories API call to resolve
-            });
-            test("they see the categories page", () => {
-                expect(h1).toBeVisible();
-            });
-            test("the document title is correct", () => {
-                expect(document.title).toEqual(`${CATEGORIES_PAGE_HEADING}${DOCUMENT_TITLE_SUFFIX}`);
-            });
-            test("the main heading is focused", async () => {
-                await waitFor(() => {
-                    expect(h1).toHaveFocus();
-                });
-            });
-        });
-
-        describe("BusinessesPage", () => {
-            beforeEach(async () => {
-                await user.click(screen.getByRole("link", { name: LINK_TEXT.businesses }));
-                h1 = await screen.findByRole("heading", { level: 1, name: BUSINESSES_PAGE_HEADING });
-                await screen.findAllByRole("heading", { level: 2 }); // wait for Businesses API call to resolve
-            });
-            test("they see the businesses page", () => {
-                expect(h1).toBeVisible();
-            });
-            test("the document title is correct", () => {
-                expect(document.title).toEqual(`${BUSINESSES_PAGE_HEADING}${DOCUMENT_TITLE_SUFFIX}`);
             });
             test("the main heading is focused", async () => {
                 await waitFor(() => {

--- a/src/layout/RouterOutlet.tsx
+++ b/src/layout/RouterOutlet.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { Route, Routes } from "react-router-dom";
-import { Categories, CATEGORIES_PAGE_HEADING } from "../pages/categories/Categories";
-import { Businesses, BUSINESSES_PAGE_HEADING } from "../pages/businesses/Businesses";
 import { ACCESSIBILITY_PAGE_HEADING, AccessibilityIssues } from "../pages/accessibility-issues/AccessibilityIssues";
 import { CONTACT_PAGE_HEADING, ContactUs } from "../pages/contact-us/ContactUs";
 import { Page } from "../pages/Page";
@@ -22,12 +20,6 @@ export const RouterOutlet = () => {
                 <Route path={PAGE_ENDPOINTS.annArborOrdinance}
                        element={<Page title={ORDINANCE_PAGE_HEADING}
                                       key={ORDINANCE_PAGE_HEADING}><AnnArborOrdinance/></Page>}/>
-                <Route path={PAGE_ENDPOINTS.categories}
-                       element={<Page title={CATEGORIES_PAGE_HEADING}
-                                      key={CATEGORIES_PAGE_HEADING}><Categories/></Page>}/>
-                <Route path={PAGE_ENDPOINTS.businesses}
-                       element={<Page title={BUSINESSES_PAGE_HEADING}
-                                      key={BUSINESSES_PAGE_HEADING}><Businesses/></Page>}/>
                 <Route path={PAGE_ENDPOINTS.accessibilityIssues}
                        element={<Page title={ACCESSIBILITY_PAGE_HEADING}
                                       key={ACCESSIBILITY_PAGE_HEADING}><AccessibilityIssues/></Page>}/>


### PR DESCRIPTION
Remove routes and links to the businesses and categories pages ahead of the first launch because we don't have data to put on them.