### PR TITLE
Add law summary page from Keta's PDF

### DIFF
--- a/src/components/MainHeading.css
+++ b/src/components/MainHeading.css
@@ -14,3 +14,9 @@ h1 {
 h1:focus {
     outline-offset: 4px;
 }
+
+@media (min-width: 961px) {
+    h1 {
+        font-size: 1.8rem;
+    }
+}

--- a/src/components/OpensInNewTab/OpensInANewTab.css
+++ b/src/components/OpensInNewTab/OpensInANewTab.css
@@ -2,11 +2,6 @@
     height: 0.8rem;
     margin-left: 0.33rem;
     min-height: 0.8rem;
-    min-width: 0.8rem;
-    width: 0.8rem;
-}
-
-.opens-in-new-tab-link {
-    align-items: center;
-    display: flex;
+    min-width: 1rem;
+    display: inline;
 }

--- a/src/components/OpensInNewTab/OpensInANewTabLink.tsx
+++ b/src/components/OpensInNewTab/OpensInANewTabLink.tsx
@@ -7,9 +7,10 @@ type NewTabLinkProps = Omit<React.HTMLProps<HTMLAnchorElement>, "target" | "rel"
 export const OPENS_IN_A_NEW_TAB = "opens in a new tab";
 
 export const OpensInANewTabLink = ({ children, className, color = "#0000ee", ...props }: NewTabLinkProps) => {
-    return (<>
-        <a target={"_blank"} rel={"noreferrer"}
-           className={`opens-in-new-tab-link ${className ?? ""}`} {...props}>{children}
-            <OpensInNewTabIcon color={color}/></a>
-    </>);
+    return (
+        <a target={"_blank"} rel={"noreferrer"} className={`${className ?? ""}`}{...props}>
+            <span>{children}</span>
+            <OpensInNewTabIcon color={color}/>
+        </a>
+    );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,6 @@ body {
     background-color: #eeeeec;
     font-family: Karla, sans-serif;
     -webkit-font-smoothing: antialiased;
-    font-weight: bold;
     margin: 0;
     -moz-osx-font-smoothing: grayscale;
 }

--- a/src/layout/RouterOutlet.test.tsx
+++ b/src/layout/RouterOutlet.test.tsx
@@ -15,7 +15,10 @@ import { LINK_TEXT } from "../components/navigation/NavLinks";
 import { ENVIRONMENT_VARIABLES, getIntegerEnvVar } from "../utilities/environment-variables";
 import { faker } from "@faker-js/faker";
 import { ID_REFUSED_PAGE_HEADING } from "../pages/report-id-refusal/ReportIdRefused";
-import { ANN_ARBOR_LAW_SUMMARY_HEADING } from "../pages/ann-arbor-law-summary/AnnArborLawSummary";
+import {
+    ANN_ARBOR_LAW_SUMMARY_DOCUMENT_TITLE,
+    ANN_ARBOR_LAW_SUMMARY_HEADING
+} from "../pages/ann-arbor-law-summary/AnnArborLawSummary";
 
 const unknownPageLinkName = "UNKNOWN PAGE";
 
@@ -83,7 +86,7 @@ describe(RouterOutlet.name, () => {
                 expect(h1).toBeVisible();
             });
             test("the document title is correct", () => {
-                expect(document.title).toEqual(`${ANN_ARBOR_LAW_SUMMARY_HEADING}${DOCUMENT_TITLE_SUFFIX}`);
+                expect(document.title).toEqual(`${ANN_ARBOR_LAW_SUMMARY_DOCUMENT_TITLE}${DOCUMENT_TITLE_SUFFIX}`);
             });
             test("the main heading is focused", async () => {
                 await waitFor(() => {

--- a/src/layout/RouterOutlet.tsx
+++ b/src/layout/RouterOutlet.tsx
@@ -5,7 +5,11 @@ import { CONTACT_PAGE_HEADING, ContactUs } from "../pages/contact-us/ContactUs";
 import { Page } from "../pages/Page";
 import { WELCOME_PAGE_HEADING, WelcomePage } from "../pages/welcome/WelcomePage";
 import { ID_REFUSED_PAGE_HEADING, ReportIdRefused } from "../pages/report-id-refusal/ReportIdRefused";
-import { ANN_ARBOR_LAW_SUMMARY_HEADING, AnnArborLawSummary } from "../pages/ann-arbor-law-summary/AnnArborLawSummary";
+import {
+    ANN_ARBOR_LAW_SUMMARY_DOCUMENT_TITLE,
+    ANN_ARBOR_LAW_SUMMARY_HEADING,
+    AnnArborLawSummary
+} from "../pages/ann-arbor-law-summary/AnnArborLawSummary";
 
 export const PAGE_ENDPOINTS = {
     home: "/",
@@ -27,7 +31,7 @@ export const RouterOutlet = () => {
                                       key={WELCOME_PAGE_HEADING}><WelcomePage/></Page>}/>
 
                 <Route path={PAGE_ENDPOINTS.annArborLaw}
-                       element={<Page title={ANN_ARBOR_LAW_SUMMARY_HEADING}
+                       element={<Page title={ANN_ARBOR_LAW_SUMMARY_DOCUMENT_TITLE}
                                       key={ANN_ARBOR_LAW_SUMMARY_HEADING}><AnnArborLawSummary/></Page>}/>
 
                 <Route path={PAGE_ENDPOINTS.reportIdRefused}

--- a/src/pages/Pages.css
+++ b/src/pages/Pages.css
@@ -23,22 +23,21 @@
     font-size: 1.25rem;
     padding: 1rem;
     box-sizing: border-box;
+    display: flex;
+    flex-flow: column wrap;
+    row-gap: 1rem;
 }
 
 .text-page-paragraph {
     display: inline-block;
-    line-height: 1.6rem;
-    margin: 0 0 1rem 0;
+    line-height: 1.5rem;
+    margin: 0;
 }
 
 @media (min-width: 961px) {
     .text-page-container {
         align-self: center;
         max-width: 66%;
-        font-size: 1.5rem;
-    }
-
-    .text-page-paragraph {
-        line-height: 2rem;
+        padding: 1rem 2rem;
     }
 }

--- a/src/pages/ann-arbor-law-summary/AnnArborLawSummary.css
+++ b/src/pages/ann-arbor-law-summary/AnnArborLawSummary.css
@@ -1,0 +1,58 @@
+.table-of-contents-heading {
+    font-size: 1.5rem;
+    margin: 0.25rem 0.25rem 0 0.25rem;
+}
+
+.table-of-contents-list {
+    display: flex;
+    flex-flow: column wrap;
+    font-size: 1.25rem;
+    margin: 0.5rem 0;
+    padding: 0 0 0 3rem;
+    row-gap: 0.75rem;
+}
+
+.law-page-section {
+    display: flex;
+    flex-flow: column wrap;
+    row-gap: 1rem;
+    margin-top: 1rem;
+}
+
+.law-page-section-heading {
+    display: inline;
+    font-size: 1.5rem;
+    font-weight: 900;
+    margin: 0.25rem 0.25rem 0 0.25rem;
+    outline-offset: 4px;
+
+}
+
+.citation-link-container {
+    display: flex;
+    justify-content: end;
+    text-align: right;
+}
+
+.citation-link {
+    font-size: 1rem;
+    margin-top: 0.4rem;
+}
+
+.contact-list {
+    margin: 0;
+}
+
+.contact-list-item {
+    margin-bottom: 0.4rem;
+}
+
+@media (min-width: 961px) {
+    .law-page-section {
+        box-sizing: border-box;
+    }
+
+    .law-page-section > p {
+        padding: 0 2rem;
+    }
+}

--- a/src/pages/ann-arbor-law-summary/AnnArborLawSummary.test.tsx
+++ b/src/pages/ann-arbor-law-summary/AnnArborLawSummary.test.tsx
@@ -1,17 +1,31 @@
-import { ANN_ARBOR_LAW_SUMMARY_HEADING, AnnArborLawSummary } from "./AnnArborLawSummary";
-import { render, screen } from "@testing-library/react";
+import {
+    ANN_ARBOR_LAW_SUMMARY_DOCUMENT_TITLE,
+    ANN_ARBOR_LAW_SUMMARY_HEADING,
+    ANN_ARBOR_LAW_SUMMARY_SECTION_1_ID,
+    ANN_ARBOR_LAW_SUMMARY_SECTION_2_ID,
+    ANN_ARBOR_LAW_SUMMARY_SECTION_3_ID,
+    ANN_ARBOR_LAW_SUMMARY_SECTION_4_ID,
+    ANN_ARBOR_LAW_SUMMARY_SECTION_5_ID,
+    ANN_ARBOR_LAW_SUMMARY_SECTION_6_ID,
+    AnnArborLawSummary
+} from "./AnnArborLawSummary";
+import { render, screen, within } from "@testing-library/react";
 import React from "react";
 import { axe } from "jest-axe";
 import { Container } from "react-dom";
-import { OPENS_IN_A_NEW_TAB } from "../../components/OpensInNewTab/OpensInANewTabLink";
+import { MemoryRouter } from "react-router-dom";
+import { PAGE_ENDPOINTS } from "../../layout/RouterOutlet";
 
 describe(AnnArborLawSummary.name, () => {
     let container: Container;
     beforeEach(() => {
-        ({ container } = render(<AnnArborLawSummary/>));
+        ({ container } = render(<MemoryRouter><AnnArborLawSummary/></MemoryRouter>));
     });
     test("exports its page heading", () => {
-        expect(ANN_ARBOR_LAW_SUMMARY_HEADING).toBe("Summary of Ann Arbor's Law");
+        expect(ANN_ARBOR_LAW_SUMMARY_HEADING).toBe("Accepting the Washtenaw ID is the Law in Ann Arbor");
+    });
+    test("exports its document title", () => {
+        expect(ANN_ARBOR_LAW_SUMMARY_DOCUMENT_TITLE).toBe("Ann Arbor Law");
     });
     test("has no AxE violations", async () => {
         const page = await axe(container as Element);
@@ -26,20 +40,206 @@ describe(AnnArborLawSummary.name, () => {
         expect(h1.hasAttribute("tabindex")).toBe(true);
         expect(h1.tabIndex).toBe(-1);
     });
-    test("has information about the law in Ann Arbor", () => {
-        const paragrah1 = screen.getByText("The City of Ann Arbor’s Non-discrimination law makes it illegal to discriminate against someone based on their government-issued ID card. That means a business must accept a Washtenaw County ID card as proof of identity just like they will accept a State of Michigan driver’s license.");
-        const paragrah2 = screen.getByText("They cannot deny you service only because you want to use a Washtenaw County ID card as proof of your identity. It’s their responsibility to recognize the ID - they cannot refuse to accept it because they’ve never seen it before. It is issued by Washtenaw County in Ann Arbor, and mentioned by name in Ann Arbor’s law.");
-        const paragrah3 = screen.getByText("The law allows you to use the Washtenaw County ID card to prove your identity for housing, employment, buying age-restricted goods like cigarettes and alcohol, and other public accommodations.");
-        const paragrah4 = screen.getByText("The full text of Ann Arbor’s non-discrimination law is in Title IX, Chapter 112, Section 9:150 - 9:164.", { exact: false });
+    describe("table of contents", () => {
+        let navElement: HTMLDivElement;
+        const headingText = "Table of Contents";
+        beforeEach(() => {
+            navElement = screen.getByRole("navigation", { name: headingText });
+        });
+        test("is a nav labelled by a heading", () => {
+            expect(navElement).toBeVisible();
 
-        expect(paragrah1).toBeVisible();
-        expect(paragrah2).toBeVisible();
-        expect(paragrah3).toBeVisible();
-        expect(paragrah4).toBeVisible();
+            const contentsHeading = within(navElement).getByRole("heading", { level: 2, name: headingText });
+            expect(contentsHeading).toBeVisible();
+        });
+        test("has a link to each section", () => {
+            const list = within(navElement).getByRole("list");
+            const listItems = within(list).getAllByRole("listitem");
+            const links: HTMLAnchorElement[] = listItems.map(listItem => within(listItem).getByRole("link"));
+            expect(links.length).toEqual(6);
+
+            expect(links[0].href.endsWith(`#${ANN_ARBOR_LAW_SUMMARY_SECTION_1_ID}`)).toBe(true);
+            expect(links[0].textContent).toEqual("Refusing the Washtenaw ID is against the law in Ann Arbor");
+
+            expect(links[1].href.endsWith(`#${ANN_ARBOR_LAW_SUMMARY_SECTION_2_ID}`)).toBe(true);
+            expect(links[1].textContent).toEqual("The Washtenaw ID is a valid government-issued ID card");
+
+            expect(links[2].href.endsWith(`#${ANN_ARBOR_LAW_SUMMARY_SECTION_3_ID}`)).toBe(true);
+            expect(links[2].textContent).toEqual("Unfamiliarity with the Washtenaw ID is no excuse");
+
+            expect(links[3].href.endsWith(`#${ANN_ARBOR_LAW_SUMMARY_SECTION_4_ID}`)).toBe(true);
+            expect(links[3].textContent).toEqual("Alcohol can be purchased with the Washtenaw ID");
+
+            expect(links[4].href.endsWith(`#${ANN_ARBOR_LAW_SUMMARY_SECTION_5_ID}`)).toBe(true);
+            expect(links[4].textContent).toEqual("Prescription medication can be purchased with the Washtenaw ID");
+
+            expect(links[5].href.endsWith(`#${ANN_ARBOR_LAW_SUMMARY_SECTION_6_ID}`)).toBe(true);
+            expect(links[5].textContent).toEqual("Investigation by the city's Human Rights Commission");
+        });
     });
-    test("has a link to Ann Arbor's law", () => {
-        const link: HTMLAnchorElement = screen.getByRole("link", { name: `Click here to see the full text of the law on Municode. ${OPENS_IN_A_NEW_TAB}` });
-        expect(link).toBeVisible();
-        expect(link.href).toEqual("https://library.municode.com/mi/ann_arbor/codes/code_of_ordinances?nodeId=TITIXPORE_CH112NSC_9_150IN");
+    describe("Section 1 - refusing the ID is against the law", () => {
+        test("has a heading", () => {
+            let heading = screen.getByRole("heading", {
+                level: 2,
+                name: "I. Refusing the Washtenaw ID is against the law in Ann Arbor"
+            });
+            expect(heading).toBeVisible();
+            expect(heading.id).toEqual(ANN_ARBOR_LAW_SUMMARY_SECTION_1_ID);
+            expect(heading.tabIndex).toBe(-1);
+
+        });
+        test("has informational paragraphs", () => {
+            const paragraph1 = screen.getByText("Ann Arbor finds the practice of denying service to otherwise eligible individuals based on the type of government-issued ID they carry, discriminatory. Municipal Code Chapter 112 makes this practice unlawful. Pursuant to the City's Non-Discrimination Ordinance: All government-issued ID cards must be accepted as valid unless a state or federal law mandates that a specific type of ID be used for a specific purpose.");
+            expect(paragraph1).toBeVisible();
+            const paragraph2 = screen.getByText("The relevant part of the law states that: \"(6) No person shall discriminate against individuals based on their use of a government-issued identification card and all persons shall accept a government-issued identification card as valid identification...\" absent very specific statutory mandate not present in everyday transactions.");
+            expect(paragraph2).toBeVisible();
+        });
+        test("has a citation of the law pointing to the law online", () => {
+            const link: HTMLAnchorElement = screen.getByRole("link", { name: "ANN ARBOR MUNICIPAL CODE CHAPTER 112, SECTION 9:155, SUBSECTION 6 opens in a new tab" });
+            expect(link).toBeVisible();
+            expect(link.href).toEqual("https://library.municode.com/mi/ann_arbor/codes/code_of_ordinances?nodeId=TITIXPORE_CH112NSC_9_155OTPRPR");
+            expect(link.target).toEqual(`_blank`);
+            expect(link.rel).toEqual(`noreferrer`);
+        });
+    });
+    describe("Section 2 - The Washteanw ID is a valid ID card", () => {
+        test("has a heading", () => {
+            let heading = screen.getByRole("heading", {
+                level: 2,
+                name: "II. The Washtenaw ID is a valid government-issued ID card. By statute it is equivalent to all other state and federal issued ID"
+            });
+            expect(heading).toBeVisible();
+            expect(heading.id).toEqual(ANN_ARBOR_LAW_SUMMARY_SECTION_2_ID);
+            expect(heading.tabIndex).toBe(-1);
+
+        });
+        test("has informational paragraphs", () => {
+            const paragraph1 = screen.getByText("The law, in relevant part provides that: \"A government-issued identification card is any identification document displaying an individual's photograph and identifying information issued by a federal, state, or local government (including a Washtenaw County identification card) to an individual for the purpose of identification of that individual.\"");
+            expect(paragraph1).toBeVisible();
+        });
+        test("has a citation of the law pointing to the law online", () => {
+            const link: HTMLAnchorElement = screen.getByRole("link", { name: "ANN ARBOR MUNICIPAL CODE CHAPTER 112, SECTION 9:151, SUBSECTION 15 opens in a new tab" });
+            expect(link).toBeVisible();
+            expect(link.href).toEqual("https://library.municode.com/mi/ann_arbor/codes/code_of_ordinances?nodeId=TITIXPORE_CH112NSC_9_151DE");
+            expect(link.target).toEqual(`_blank`);
+            expect(link.rel).toEqual(`noreferrer`);
+        });
+    });
+    describe("Section 3 - Lack of Familiarity", () => {
+        test("has a heading", () => {
+            let heading = screen.getByRole("heading", {
+                level: 2,
+                name: "III. Lack of familiarity with the Washtenaw ID is not a legal justification for denying equal access to goods and services"
+            });
+            expect(heading).toBeVisible();
+            expect(heading.id).toEqual(ANN_ARBOR_LAW_SUMMARY_SECTION_3_ID);
+            expect(heading.tabIndex).toBe(-1);
+
+        });
+        test("has informational paragraphs", () => {
+            const paragraph1 = screen.getByText("All persons presenting a current photo ID issued by a government of the United States, (including local government ID cards like the Washtenaw ID) are entitled to full and equal access to goods and services. Lack of familiarity with a particular government-issued ID does not constitute legitimate grounds for the human rights violation inherent in withholding access to necessary goods and services.");
+            expect(paragraph1).toBeVisible();
+        });
+        test("has a citation of the law pointing to the law online", () => {
+            const link: HTMLAnchorElement = screen.getByRole("link", { name: "ANN ARBOR MUNICIPAL CODE CHAPTER 112, SECTION 9:150 opens in a new tab" });
+            expect(link).toBeVisible();
+            expect(link.href).toEqual("https://library.municode.com/mi/ann_arbor/codes/code_of_ordinances?nodeId=TITIXPORE_CH112NSC_9_150IN");
+            expect(link.target).toEqual(`_blank`);
+            expect(link.rel).toEqual(`noreferrer`);
+        });
+    });
+    describe("Section 4 - Alcohol", () => {
+        test("has a heading", () => {
+            let heading = screen.getByRole("heading", {
+                level: 2,
+                name: "IV. Alcohol can be purchased with the Washtenaw ID"
+            });
+            expect(heading).toBeVisible();
+            expect(heading.id).toEqual(ANN_ARBOR_LAW_SUMMARY_SECTION_4_ID);
+            expect(heading.tabIndex).toBe(-1);
+
+        });
+        test("has informational paragraphs", () => {
+            const paragraph1 = screen.getByText("You do not need a state ID to purchase alcohol in Michigan. MI law requires a \"...bona fide picture identification which establishes the identity and age of the person.\"");
+            expect(paragraph1).toBeVisible();
+            const paragraph2 = screen.getByText("A relevant part the statute requires that sellers make \"...a diligent good faith effort to determine the age of the person, which includes at least an examination of...bona fide picture identification which establishes the identity and age of the person.\"");
+            expect(paragraph2).toBeVisible();
+        });
+        test("has citations of the laws pointing to the laws online", () => {
+            const link: HTMLAnchorElement = screen.getByRole("link", { name: "MICHIGAN COMPILED LAWS 436.1701 SECTION 701 SUBSECTION 11 (B) (i) opens in a new tab" });
+            expect(link).toBeVisible();
+            expect(link.href).toEqual("https://www.legislature.mi.gov/(S(rvyziyt3emr4l2nydyymkrko))/mileg.aspx?page=getObject&objectName=mcl-436-1701");
+            expect(link.target).toEqual(`_blank`);
+            expect(link.rel).toEqual(`noreferrer`);
+        });
+    });
+    describe("Section 5 - Prescription Medication", () => {
+        test("has a heading", () => {
+            let heading = screen.getByRole("heading", {
+                level: 2,
+                name: "V. Prescription medication and cold medicine can be purchased with the Washtenaw ID"
+            });
+            expect(heading).toBeVisible();
+            expect(heading.id).toEqual(ANN_ARBOR_LAW_SUMMARY_SECTION_5_ID);
+            expect(heading.tabIndex).toBe(-1);
+
+        });
+        test("has informational paragraphs", () => {
+            const paragraph1 = screen.getByText("You do not need a state ID to purchase restricted prescribed medication nor is a state ID required for ephedrine or pseudoephedrine at adult doses in Michigan. MI law requires \"...a valid government-issued photo identification that includes the individual's name and date of birth.\" The pharmacy is required to document the type of ID used, the purchasers information, and may ask the purchaser to sign a log.");
+            expect(paragraph1).toBeVisible();
+        });
+        test("has a citation of the law pointing to the law online", () => {
+            const link: HTMLAnchorElement = screen.getByRole("link", { name: "MICHIGAN COMPILED LAWS 333.17766e SECTION 17766e SUBSECTION 2 (A) opens in a new tab" });
+            expect(link).toBeVisible();
+            expect(link.href).toEqual("https://www.legislature.mi.gov/(S(rvyziyt3emr4l2nydyymkrko))/mileg.aspx?page=getObject&objectName=mcl-333-17766e");
+            expect(link.target).toEqual(`_blank`);
+            expect(link.rel).toEqual(`noreferrer`);
+        });
+    });
+    describe("Section 6 - Investigation by Human Rights Commission", () => {
+        test("has a heading", () => {
+            let heading = screen.getByRole("heading", {
+                level: 2,
+                name: "VI. Washtenaw ID discrimination is investigated by the city's Human Rights Commission"
+            });
+            expect(heading).toBeVisible();
+            expect(heading.id).toEqual(ANN_ARBOR_LAW_SUMMARY_SECTION_6_ID);
+            expect(heading.tabIndex).toBe(-1);
+
+        });
+        test("has informational paragraphs", () => {
+            const paragraph1 = screen.getByText("The City of Ann Arbor's Human Rights Commission is authorized to \"Receive and review complaints from individuals alleging violations of Ann Arbor's human rights ordinance and take appropriate action, including but not limited to referral of complaints to appropriate agencies or to the City Attorney mediation of complaints, or dismissal of complaints\"");
+            expect(paragraph1).toBeVisible();
+            const paragraph2 = screen.getByText("If you have questions or want to report ID discrimination, you can contact the Human Rights Commission by phone or email at the links below.");
+            expect(paragraph2).toBeVisible();
+            const paragraph3 = screen.getByText("You can also contact the Washtenaw ID Project directly through this website.", { exact: false });
+            expect(paragraph3).toBeVisible();
+        });
+        test("has a citation of the law pointing to the law online", () => {
+            const link: HTMLAnchorElement = screen.getByRole("link", { name: "ANN ARBOR MUNICIPAL CODE CHAPTER 8, SECTION 1:222 (a) opens in a new tab" });
+            expect(link).toBeVisible();
+            expect(link.href).toEqual("https://library.municode.com/mi/ann_arbor/codes/code_of_ordinances?nodeId=TITIAD_CH8ORBOCO_1_222SAUT");
+            expect(link.target).toEqual(`_blank`);
+            expect(link.rel).toEqual(`noreferrer`);
+        });
+        test("has contact information for complaining about ID discrimination", () => {
+            const contactSection = screen.getByTestId("section-6");
+            const list = within(contactSection).getByRole("list");
+            const listItems = within(list).getAllByRole("listitem");
+            const links: HTMLAnchorElement[] = listItems.map(listItem => within(listItem).getByRole("link"));
+            expect(links.length).toEqual(3);
+
+            expect(links[0].href).toEqual("tel:+1(734)794-6291");
+            expect(links[0].textContent).toEqual("(734) 794-6291");
+
+            expect(links[1].href).toEqual("mailto:hrc@a2gov.org");
+            expect(links[1].textContent).toEqual("hrc@a2gov.org");
+
+            expect(links[2].href).toEqual("mailto:kcummings@a2gov.org");
+            expect(links[2].textContent).toEqual("kcummings@a2gov.org");
+
+            const contactUsLink: HTMLAnchorElement = screen.getByRole("link", { name: "Click here to contact us." });
+            expect(contactUsLink.href.endsWith(PAGE_ENDPOINTS.reportIdRefused)).toBe(true);
+        });
     });
 });

--- a/src/pages/ann-arbor-law-summary/AnnArborLawSummary.tsx
+++ b/src/pages/ann-arbor-law-summary/AnnArborLawSummary.tsx
@@ -1,40 +1,216 @@
 import React from "react";
 import { MainHeading } from "../../components/MainHeading";
 import { OpensInANewTabLink } from "../../components/OpensInNewTab/OpensInANewTabLink";
+import "./AnnArborLawSummary.css";
+import { AppLink } from "../../components/navigation/AppLink";
+import { PAGE_ENDPOINTS } from "../../layout/RouterOutlet";
 
-export const ANN_ARBOR_LAW_SUMMARY_HEADING = "Summary of Ann Arbor's Law";
+export const ANN_ARBOR_LAW_SUMMARY_HEADING = "Accepting the Washtenaw ID is the Law in Ann Arbor";
+export const ANN_ARBOR_LAW_SUMMARY_DOCUMENT_TITLE = "Ann Arbor Law";
+
+export const ANN_ARBOR_LAW_SUMMARY_SECTION_1_ID = "section-1";
+export const ANN_ARBOR_LAW_SUMMARY_SECTION_2_ID = "section-2";
+export const ANN_ARBOR_LAW_SUMMARY_SECTION_3_ID = "section-3";
+export const ANN_ARBOR_LAW_SUMMARY_SECTION_4_ID = "section-4";
+export const ANN_ARBOR_LAW_SUMMARY_SECTION_5_ID = "section-5";
+export const ANN_ARBOR_LAW_SUMMARY_SECTION_6_ID = "section-6";
 
 export const AnnArborLawSummary = () => {
-    return (
-        <div className={"text-page-container"}>
+    return (<>
             <MainHeading>{ANN_ARBOR_LAW_SUMMARY_HEADING}</MainHeading>
-            <p className={"text-page-paragraph"}>
-                The City of Ann Arbor’s Non-discrimination law makes it illegal to discriminate against someone based on
-                their government-issued ID card. That means a business must accept a Washtenaw County ID card as proof
-                of
-                identity just like they will accept a State of Michigan driver’s license.
-            </p>
-            <p className={"text-page-paragraph"}>
-                They cannot deny you service only because you want to use a Washtenaw County ID card as proof of your
-                identity. It’s their responsibility to recognize the ID - they cannot refuse to accept it because
-                they’ve
-                never seen it before. It is issued by Washtenaw County in Ann Arbor, and mentioned by name in Ann
-                Arbor’s
-                law.
-            </p>
-            <p className={"text-page-paragraph"}>
-                The law allows you to use the Washtenaw County ID card to prove your identity for housing, employment,
-                buying age-restricted goods like cigarettes and alcohol, and other public accommodations.
-            </p>
-            <p className={"text-page-paragraph"}>
-                The full text of Ann Arbor’s non-discrimination law is in Title IX, Chapter 112, Section 9:150 - 9:164.
-            </p>
-            <p className={"text-page-paragraph"}>
-                <OpensInANewTabLink
-                    href={"https://library.municode.com/mi/ann_arbor/codes/code_of_ordinances?nodeId=TITIXPORE_CH112NSC_9_150IN"}>
-                    Click here to see the full text of the law on Municode.
-                </OpensInANewTabLink>
-            </p>
-        </div>
+            <div className={"text-page-container"}>
+
+                <nav aria-labelledby={"table-of-contents-heading"}>
+                    <h2 className={"table-of-contents-heading"} id={"table-of-contents-heading"}>Table of Contents</h2>
+                    <ol type={"I"} className={"table-of-contents-list"}>
+                        <li className={"table-of-contents-list-item"}>
+                            <a href={`#${ANN_ARBOR_LAW_SUMMARY_SECTION_1_ID}`}>
+                                Refusing the Washtenaw ID is against the law in Ann Arbor
+                            </a>
+                        </li>
+                        <li className={"table-of-contents-list-item"}>
+                            <a href={`#${ANN_ARBOR_LAW_SUMMARY_SECTION_2_ID}`}>
+                                The Washtenaw ID is a valid government-issued ID card
+                            </a>
+                        </li>
+                        <li className={"table-of-contents-list-item"}>
+                            <a href={`#${ANN_ARBOR_LAW_SUMMARY_SECTION_3_ID}`}>
+                                Unfamiliarity with the Washtenaw ID is no excuse
+                            </a>
+                        </li>
+                        <li className={"table-of-contents-list-item"}>
+                            <a href={`#${ANN_ARBOR_LAW_SUMMARY_SECTION_4_ID}`}>
+                                Alcohol can be purchased with the Washtenaw ID
+                            </a>
+                        </li>
+                        <li className={"table-of-contents-list-item"}>
+                            <a href={`#${ANN_ARBOR_LAW_SUMMARY_SECTION_5_ID}`}>
+                                Prescription medication can be purchased with the Washtenaw ID
+                            </a>
+                        </li>
+                        <li className={"table-of-contents-list-item"}>
+                            <a href={`#${ANN_ARBOR_LAW_SUMMARY_SECTION_6_ID}`}>
+                                Investigation by the city's Human Rights Commission
+                            </a>
+                        </li>
+                    </ol>
+                </nav>
+
+                <div className={"law-page-section"}>
+                    <h2 id={ANN_ARBOR_LAW_SUMMARY_SECTION_1_ID} className={"law-page-section-heading"} tabIndex={-1}>
+                        I. Refusing the Washtenaw ID is against the law in Ann Arbor
+                    </h2>
+
+                    <p className={"text-page-paragraph"}>
+                        Ann Arbor finds the practice of denying service to otherwise eligible individuals based on the
+                        type of government-issued ID they carry, discriminatory. Municipal Code Chapter 112 makes this
+                        practice unlawful. Pursuant to the City's Non-Discrimination Ordinance: All government-issued ID
+                        cards must be accepted as valid unless a state or federal law mandates that a specific type of
+                        ID be used for a specific purpose.
+                    </p>
+                    <p className={"text-page-paragraph"}>
+                        The relevant part of the law states that: "(6) No person shall discriminate against individuals
+                        based on their use of a government-issued identification card and all persons shall accept a
+                        government-issued identification card as valid identification..." absent very specific statutory
+                        mandate not present in everyday transactions.
+                        <span className={"citation-link-container"}>
+                            <OpensInANewTabLink
+                                href={"https://library.municode.com/mi/ann_arbor/codes/code_of_ordinances?nodeId=TITIXPORE_CH112NSC_9_155OTPRPR"}
+                                className={"citation-link"}
+                            >
+                                ANN ARBOR MUNICIPAL CODE CHAPTER 112, SECTION 9:155, SUBSECTION 6
+                            </OpensInANewTabLink>
+                        </span>
+                    </p>
+                </div>
+
+                <div className={"law-page-section"}>
+                    <h2 id={ANN_ARBOR_LAW_SUMMARY_SECTION_2_ID} className={"law-page-section-heading"} tabIndex={-1}>
+                        II. The Washtenaw ID is a valid government-issued ID card. By statute it is equivalent to all
+                        other state and federal issued ID
+                    </h2>
+                    <p className={"text-page-paragraph"}>
+                        The law, in relevant part provides that: "A government-issued identification card is any
+                        identification document displaying an individual's photograph and identifying information issued
+                        by a federal, state, or local government (including a Washtenaw County identification card) to
+                        an individual for the purpose of identification of that individual."
+                        <span className={"citation-link-container"}>
+                            <OpensInANewTabLink
+                                href={"https://library.municode.com/mi/ann_arbor/codes/code_of_ordinances?nodeId=TITIXPORE_CH112NSC_9_151DE"}
+                                className={"citation-link"}
+                            >
+                                ANN ARBOR MUNICIPAL CODE CHAPTER 112, SECTION 9:151, SUBSECTION 15
+                            </OpensInANewTabLink>
+                        </span>
+                    </p>
+                </div>
+
+                <div className={"law-page-section"}>
+                    <h2 id={ANN_ARBOR_LAW_SUMMARY_SECTION_3_ID} className={"law-page-section-heading"} tabIndex={-1}>
+                        III. Lack of familiarity with the Washtenaw ID is not a legal justification for denying equal
+                        access to goods and services
+                    </h2>
+                    <p className={"text-page-paragraph"}>
+                        All persons presenting a current photo ID issued by a government of the United States,
+                        (including local government ID cards like the Washtenaw ID) are entitled to full and equal
+                        access to goods and services. Lack of familiarity with a particular government-issued ID does
+                        not constitute legitimate grounds for the human rights violation inherent in withholding access
+                        to necessary goods and services.
+                        <span className={"citation-link-container"}>
+                            <OpensInANewTabLink
+                                href={"https://library.municode.com/mi/ann_arbor/codes/code_of_ordinances?nodeId=TITIXPORE_CH112NSC_9_150IN"}
+                                className={"citation-link"}
+                            >
+                                ANN ARBOR MUNICIPAL CODE CHAPTER 112, SECTION 9:150
+                            </OpensInANewTabLink>
+                        </span>
+                    </p>
+                </div>
+
+                <div className={"law-page-section"}>
+                    <h2 id={ANN_ARBOR_LAW_SUMMARY_SECTION_4_ID} className={"law-page-section-heading"} tabIndex={-1}>
+                        IV. Alcohol can be purchased with the Washtenaw ID
+                    </h2>
+                    <p className={"text-page-paragraph"}>
+                        You do not need a state ID to purchase alcohol in Michigan. MI law requires a "...bona fide
+                        picture identification which establishes the identity and age of the person."
+                    </p>
+                    <p className={"text-page-paragraph"}
+                    >
+                        A relevant part the statute requires that sellers make "...a diligent good faith effort to
+                        determine the age of the person, which includes at least an examination of...bona fide picture
+                        identification which establishes the identity and age of the person."
+                        <span className={"citation-link-container"}>
+                            <OpensInANewTabLink
+                                href={"https://www.legislature.mi.gov/(S(rvyziyt3emr4l2nydyymkrko))/mileg.aspx?page=getObject&objectName=mcl-436-1701"}
+                                className={"citation-link"}
+                            >
+                                MICHIGAN COMPILED LAWS 436.1701 SECTION 701 SUBSECTION 11 (B) (i)
+                            </OpensInANewTabLink>
+                        </span>
+                    </p>
+                </div>
+
+                <div className={"law-page-section"}>
+                    <h2 id={ANN_ARBOR_LAW_SUMMARY_SECTION_5_ID} className={"law-page-section-heading"} tabIndex={-1}>
+                        V. Prescription medication and cold medicine can be purchased with the Washtenaw ID
+                    </h2>
+                    <p className={"text-page-paragraph"}>
+                        You do not need a state ID to purchase restricted prescribed medication nor is a state ID
+                        required for ephedrine or pseudoephedrine at adult doses in Michigan. MI law requires "...a
+                        valid government-issued photo identification that includes the individual's name and date of
+                        birth." The pharmacy is required to document the type of ID used, the purchasers information,
+                        and may ask the purchaser to sign a log.
+                        <span className={"citation-link-container"}>
+                            <OpensInANewTabLink
+                                href={"https://www.legislature.mi.gov/(S(rvyziyt3emr4l2nydyymkrko))/mileg.aspx?page=getObject&objectName=mcl-333-17766e"}
+                                className={"citation-link"}
+                            >
+                                MICHIGAN COMPILED LAWS 333.17766e SECTION 17766e SUBSECTION 2 (A)
+                            </OpensInANewTabLink>
+                        </span>
+                    </p>
+                </div>
+
+                <div className={"law-page-section"} data-testid={"section-6"}>
+                    <h2 id={ANN_ARBOR_LAW_SUMMARY_SECTION_6_ID} className={"law-page-section-heading"} tabIndex={-1}>
+                        VI. Washtenaw ID discrimination is investigated by the city's Human Rights Commission
+                    </h2>
+                    <p className={"text-page-paragraph"}>
+                        The City of Ann Arbor's Human Rights Commission is authorized to "Receive and review complaints
+                        from individuals alleging violations of Ann Arbor's human rights ordinance and take appropriate
+                        action, including but not limited to referral of complaints to appropriate agencies or to the
+                        City Attorney mediation of complaints, or dismissal of complaints"
+                        <span className={"citation-link-container"}>
+                            <OpensInANewTabLink
+                                href={"https://library.municode.com/mi/ann_arbor/codes/code_of_ordinances?nodeId=TITIAD_CH8ORBOCO_1_222SAUT"}
+                                className={"citation-link"}
+                            >
+                                ANN ARBOR MUNICIPAL CODE CHAPTER 8, SECTION 1:222 (a)
+                            </OpensInANewTabLink>
+                        </span>
+                    </p>
+                    <p className={"text-page-paragraph"}>
+                        If you have questions or want to report ID discrimination, you can contact the Human Rights
+                        Commission by phone or email at the links below.
+                    </p>
+                    <ul className={"contact-list"}>
+                        <li className={"contact-list-item"}>Office Phone:&nbsp;<a href={"tel:+1(734)794-6291"}>(734)
+                            794-6291</a></li>
+                        <li className={"contact-list-item"}>Email:&nbsp;<a
+                            href={"mailto:hrc@a2gov.org"}>hrc@a2gov.org</a></li>
+                        <li className={"contact-list-item"}>Ann Arbor city staff liaison Kennedi Blair
+                            Cummings: &nbsp;<a
+                                href={"mailto:kcummings@a2gov.org"}>kcummings@a2gov.org</a></li>
+                    </ul>
+                    <p className={"text-page-paragraph"}>
+                        You can also contact the Washtenaw ID Project directly through this website.&nbsp;
+                        <AppLink to={PAGE_ENDPOINTS.reportIdRefused} className={"inline-link"}>
+                            Click here to contact us.
+                        </AppLink>
+                    </p>
+                </div>
+            </div>
+        </>
     );
 };

--- a/src/pages/welcome/WelcomePage.css
+++ b/src/pages/welcome/WelcomePage.css
@@ -18,7 +18,11 @@
 
 .transcript-heading {
     align-self: center;
-    margin-top: 0;
+    margin: 0;
+}
+
+.transcript-speaker-name {
+    font-weight: bold;
 }
 
 @media (min-width: 961px) {

--- a/src/pages/welcome/WelcomePage.test.tsx
+++ b/src/pages/welcome/WelcomePage.test.tsx
@@ -81,13 +81,20 @@ describe(WelcomePage.name, () => {
         });
         test("has a transcript of the video", () => {
             expect(within(transcriptContainer).getByText("The video above contains interviews with people involved in the Washtenaw ID Project. While each person is talking, we see them speaking directly to the camera.")).toBeVisible();
-            expect(within(transcriptContainer).getByText("Keta Cowan - Co-Founder and Chair, The Washtenaw ID Project: \"40,000 individuals both citizens and undocumented folks lack an ID card in Washtenaw County. The Washtenaw ID Project is a local initiative to provide a government-issued ID card to those who cannot access a state ID.\"")).toBeVisible();
-            expect(within(transcriptContainer).getByText("Jerry L. Clayton - Sheriff, Washtenaw County: \"My grandparents came up to live with my parents from the south. They didn't have a birth certificate. They didn't have a Social Security card.\"")).toBeVisible();
-            expect(within(transcriptContainer).getByText("Yousef Rabhi - Michigan State Representative, 53rd District: \"You don't have those privileges. You don't have those advantages.\"")).toBeVisible();
-            expect(within(transcriptContainer).getByText("Janelle Zini - Co-Founder, Washtenaw ID Project: \"Think about where you get asked for your ID - it's almost daily.\"")).toBeVisible();
-            expect(within(transcriptContainer).getByText("Sheriff Clayton: \"Not being able to get a bank account, not being able to um sometimes secure uh a house or an apartment or a job.\"")).toBeVisible();
-            expect(within(transcriptContainer).getByText("Laura Radzik - AVP, Old National Bank: \"Old National accepts the Washtenaw ID as a primary form of identification meaning it works the same as if you had a driver's license or a passport.\"")).toBeVisible();
-            expect(within(transcriptContainer).getByText("Rep. Rabhi: \"This ID card is really in my opinion the most American thing that we could do. It is the most in line with our values of who we are as a country.\"")).toBeVisible();
+            expect(within(transcriptContainer).getByText("Keta Cowan - Co-Founder and Chair, The Washtenaw ID Project:")).toBeVisible();
+            expect(within(transcriptContainer).getByText("\"40,000 individuals both citizens and undocumented folks lack an ID card in Washtenaw County. The Washtenaw ID Project is a local initiative to provide a government-issued ID card to those who cannot access a state ID.\"")).toBeVisible();
+            expect(within(transcriptContainer).getByText("Jerry L. Clayton - Sheriff, Washtenaw County:")).toBeVisible();
+            expect(within(transcriptContainer).getByText("\"My grandparents came up to live with my parents from the south. They didn't have a birth certificate. They didn't have a Social Security card.\"")).toBeVisible();
+            expect(within(transcriptContainer).getByText("Yousef Rabhi - Michigan State Representative, 53rd District:")).toBeVisible();
+            expect(within(transcriptContainer).getByText("\"You don't have those privileges. You don't have those advantages.\"")).toBeVisible();
+            expect(within(transcriptContainer).getByText("Janelle Zini - Co-Founder, Washtenaw ID Project:")).toBeVisible();
+            expect(within(transcriptContainer).getByText("\"Think about where you get asked for your ID - it's almost daily.\"")).toBeVisible();
+            expect(within(transcriptContainer).getByText("Sheriff Clayton:")).toBeVisible();
+            expect(within(transcriptContainer).getByText("\"Not being able to get a bank account, not being able to um sometimes secure uh a house or an apartment or a job.\"")).toBeVisible();
+            expect(within(transcriptContainer).getByText("Laura Radzik - Assistant Vice President, Old National Bank:")).toBeVisible();
+            expect(within(transcriptContainer).getByText("\"Old National accepts the Washtenaw ID as a primary form of identification meaning it works the same as if you had a driver's license or a passport.\"")).toBeVisible();
+            expect(within(transcriptContainer).getByText("Rep. Rabhi:")).toBeVisible();
+            expect(within(transcriptContainer).getByText("\"This ID card is really in my opinion the most American thing that we could do. It is the most in line with our values of who we are as a country.\"")).toBeVisible();
         });
     });
 

--- a/src/pages/welcome/WelcomePage.tsx
+++ b/src/pages/welcome/WelcomePage.tsx
@@ -38,26 +38,42 @@ export const WelcomePage = () => {
         </div>
         <div className={"text-page-container transcript-container"} data-testid={"transcript-container"}>
             <h3 className={"transcript-heading"}>Video Transcript</h3>
-            <p className={"text-page-paragraph"}>The video above contains interviews with people involved in the
-                Washtenaw ID Project. While each person is talking, we see them speaking directly to the camera.</p>
-            <p className={"text-page-paragraph"}>Keta Cowan - Co-Founder and Chair, The Washtenaw ID Project: "40,000
-                individuals both citizens and undocumented folks lack an ID card in Washtenaw County. The Washtenaw ID
-                Project is a local initiative to provide a government-issued ID card to those who cannot access a state
-                ID."</p>
-            <p className={"text-page-paragraph"}>Jerry L. Clayton - Sheriff, Washtenaw County: "My grandparents came up
-                to live with my parents from the south. They didn't have a birth certificate. They didn't have a Social
-                Security card."</p>
-            <p className={"text-page-paragraph"}>Yousef Rabhi - Michigan State Representative, 53rd District: "You
-                don't have those privileges. You don't have those advantages."</p>
-            <p className={"text-page-paragraph"}>Janelle Zini - Co-Founder, Washtenaw ID Project: "Think about where
-                you get asked for your ID - it's almost daily."</p>
-            <p className={"text-page-paragraph"}>Sheriff Clayton: "Not being able to get a bank account, not being able
-                to um sometimes secure uh a house or an apartment or a job."</p>
-            <p className={"text-page-paragraph"}>Laura Radzik - AVP, Old National Bank: "Old National accepts the
-                Washtenaw ID as a primary form of identification meaning it works the same as if you had a driver's
-                license or a passport."</p>
-            <p className={"text-page-paragraph"}>Rep. Rabhi: "This ID card is really in my opinion the most American
-                thing that we could do. It is the most in line with our values of who we are as a country."</p>
+            <p className={"text-page-paragraph"}>
+                The video above contains interviews with people involved in the Washtenaw ID Project. While each person
+                is talking, we see them speaking directly to the camera.</p>
+            <p className={"text-page-paragraph"}>
+                <span
+                    className={"transcript-speaker-name"}>Keta Cowan - Co-Founder and Chair, The Washtenaw ID Project:</span> "40,000
+                individuals both
+                citizens and undocumented folks lack an ID card in Washtenaw County. The Washtenaw ID Project is a local
+                initiative to provide a government-issued ID card to those who cannot access a state ID."</p>
+            <p className={"text-page-paragraph"}>
+                <span className={"transcript-speaker-name"}>Jerry L. Clayton - Sheriff, Washtenaw County:</span> "My
+                grandparents came up to live with my
+                parents from the south. They didn't have a birth certificate. They didn't have a Social Security card."
+            </p>
+            <p className={"text-page-paragraph"}>
+                <span
+                    className={"transcript-speaker-name"}>Yousef Rabhi - Michigan State Representative, 53rd District:</span> "You
+                don't have those
+                privileges. You don't have those advantages."</p>
+            <p className={"text-page-paragraph"}>
+                <span
+                    className={"transcript-speaker-name"}>Janelle Zini - Co-Founder, Washtenaw ID Project:</span> "Think
+                about where you get asked for your
+                ID - it's almost daily."</p>
+            <p className={"text-page-paragraph"}>
+                <span className={"transcript-speaker-name"}>Sheriff Clayton:</span> "Not being able to get a bank
+                account, not being able to um sometimes
+                secure uh a house or an apartment or a job."</p>
+            <p className={"text-page-paragraph"}>
+                <span className={"transcript-speaker-name"}>Laura Radzik - Assistant Vice President, Old National Bank:
+                </span>"Old National accepts the Washtenaw ID as a primary form of identification meaning it works the
+                same as if you had a driver's license or a passport."</p>
+            <p className={"text-page-paragraph"}>
+                <span className={"transcript-speaker-name"}>Rep. Rabhi:</span> "This ID card is really in my opinion the
+                most American thing that we could do.
+                It is the most in line with our values of who we are as a country."</p>
         </div>
     </>);
 };


### PR DESCRIPTION
Separate document title and heading for law summary page Add table of contents and style
Make section headings focusable so when the user clicks on a hash link to go to one, their focus goes there too. Add ways to contact us and the Human Rights Commission Spell check and text style consistency
Fix issues from orange dotting