### PR TITLE
Prefix css

### DIFF
--- a/src/components/form/Form.css
+++ b/src/components/form/Form.css
@@ -1,37 +1,12 @@
-/*
-* Prefixed by https://autoprefixer.github.io
-* PostCSS: v8.4.14,
-* Autoprefixer: v10.4.7
-* Browsers: >0.01% and not dead and not op_mini all
-*/
-
 .form-container {
-    -moz-box-direction: normal;
-    -webkit-box-direction: normal;
-    -moz-box-orient: vertical;
-    -webkit-box-orient: vertical;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -moz-box;
     display: flex;
-    -webkit-flex-flow: column nowrap;
     flex-flow: column nowrap;
     height: 100%;
 }
 
 .form {
-    -moz-box-direction: normal;
-    -webkit-box-direction: normal;
-    -moz-box-orient: vertical;
-    -webkit-box-orient: vertical;
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
-    display: -moz-box;
     display: flex;
-
-    display: -webkit-box;
-    display: -webkit-flex;
-    -webkit-flex-flow: column nowrap;
     flex-flow: column nowrap;
     font-weight: normal;
     height: 100%;

--- a/src/components/userMessage/UserMessageNotification.css
+++ b/src/components/userMessage/UserMessageNotification.css
@@ -1,15 +1,7 @@
 .user-message {
-    -webkit-align-items: center;
     align-items: center;
-    -moz-box-align: center;
-    -webkit-box-align: center;
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
-    display: -webkit-box;
-    display: -webkit-flex;
-    display: -moz-box;
     display: flex;
-    -webkit-flex-wrap: nowrap;
     flex-wrap: nowrap;
     margin-bottom: 1.5rem;
     padding: 1rem;

--- a/src/index.css
+++ b/src/index.css
@@ -10,9 +10,7 @@ a:focus, a:hover {
 body {
     background-color: #eeeeec;
     font-family: Karla, sans-serif;
-    -webkit-font-smoothing: antialiased;
     margin: 0;
-    -moz-osx-font-smoothing: grayscale;
 }
 
 :focus {

--- a/src/pages/ann-arbor-law-summary/AnnArborLawSummary.css
+++ b/src/pages/ann-arbor-law-summary/AnnArborLawSummary.css
@@ -30,7 +30,7 @@
 
 .citation-link-container {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
     text-align: right;
 }
 


### PR DESCRIPTION
https://trello.com/c/pL3IaU1R/67-use-auto-prefixer-on-all-css

I removed all the prefixed CSS values from the CSS source files. Create React App automatically prefixes them when it builds.

I also fixed a value of `justify-content: end;` to `justify-content: flex-end;`. `end` is poorly supported.