### PR TITLE
Track spam form submissions

### DIFF
--- a/src/components/form/Form.test.tsx
+++ b/src/components/form/Form.test.tsx
@@ -13,12 +13,16 @@ import { FormField } from "./FormField";
 import { Validator } from "../../hooks/form-validation/useValidation";
 import { RadioButtonGroup, RadioOption } from "./RadioButtonGroup";
 import { USER_EVENT_KEYS_FOR_TESTING_ONLY } from "../../../test/user-event-keys";
+import { now } from "../../utilities/date-utilities";
+import mocked = jest.mocked;
 
 const submitEndpoint = "form-submit-endpoint";
 const formLabelText = "Short information about the form";
 
 const successMessage = "Your issue has been reported, thank you!";
 const pageIdentifier = "test-page";
+
+jest.mock("../../utilities/date-utilities");
 
 describe(Form.name, () => {
     let capturedFormData: AccessibilityFormData;
@@ -141,7 +145,14 @@ describe(Form.name, () => {
             let honeypotInput: HTMLInputElement;
             const honeypotValue = "I'm a robot";
 
+            const timeFormWasRendered = 42892453216246;
+            const timeFormWasSubmitted = 42892453641411;
+
             beforeEach(async () => {
+                mocked(now)
+                    .mockName("now")
+                    .mockReturnValueOnce(timeFormWasRendered)
+                    .mockReturnValueOnce(timeFormWasSubmitted);
                 render(<FormWithInputs/>);
 
                 form = screen.getByRole("form");
@@ -197,7 +208,13 @@ describe(Form.name, () => {
             });
 
             test("the form's data is sent to the server", async () => {
-                expect(capturedFormData).toEqual({ name, age, color, honeypotValue });
+                expect(capturedFormData).toEqual({
+                    name,
+                    age,
+                    color,
+                    honeypotValue,
+                    timeToFillForm: `${timeFormWasSubmitted - timeFormWasRendered} milliseconds`
+                });
             });
 
             describe("when form submission succeeds", () => {

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -16,6 +16,8 @@ type FormProps = ChildrenProps & {
     successMessage: string
 }
 
+export type HoneypotFormData = { honeypotValue: string, timeToFillForm: string };
+
 export const Form = ({ children, ariaLabelledBy, submitEndpoint, successMessage }: FormProps) => {
     const responseMessage = useRef<HTMLSpanElement>(null);
 
@@ -57,7 +59,9 @@ export const Form = ({ children, ariaLabelledBy, submitEndpoint, successMessage 
             setLiveRegionText("submitting");
 
             const formData = extractFormData(form);
-            formData.timeToFillForm = `${now() - timeBeganFillingForm} milliseconds`;
+
+            const timeFormWasSubmitted = now();
+            formData.timeToFillForm = `${timeFormWasSubmitted - timeBeganFillingForm} milliseconds`;
 
             postFormData(formData, (ok, _, error) => {
                 setSubmitting(false);
@@ -65,6 +69,7 @@ export const Form = ({ children, ariaLabelledBy, submitEndpoint, successMessage 
 
                 if (ok) {
                     onClearObservable.notify();
+                    setTimeBeganFillingForm(now());
                     setShowSuccessMessage(true);
                 } else {
                     setErrorMessage(error);

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -95,6 +95,15 @@ export const Form = ({ children, ariaLabelledBy, submitEndpoint, successMessage 
                         {liveRegionText}
                     </div>
                 </div>
+                <div className={"display-none"} data-testid={"honeypot"}>
+                    <label htmlFor={"robot-input"}>
+                        Robot Input
+                        <input name={"honeypotValue"} id={"robot-input"} aria-describedby={"honeypot-description"}/>
+                    </label>
+                    <p id={"honeypot-description"}>
+                        This field is a trap for robots to prevent spam. Please don't fill it out.
+                    </p>
+                </div>
             </form>
         </div>
     );

--- a/src/components/form/Form.tsx
+++ b/src/components/form/Form.tsx
@@ -8,6 +8,7 @@ import { FormProvider } from "../../contexts/FormContext";
 import { Observable } from "../../utilities/observable";
 import { SubmitLoadingIcon } from "./SubmitLoadingIcon";
 import { useLiveRegionText } from "../../hooks/useLiveRegionText";
+import { now } from "../../utilities/date-utilities";
 
 type FormProps = ChildrenProps & {
     ariaLabelledBy: string
@@ -23,6 +24,7 @@ export const Form = ({ children, ariaLabelledBy, submitEndpoint, successMessage 
     const [showSuccessMessage, setShowSuccessMessage] = useState<boolean>(false);
     const [errorMessage, setErrorMessage] = useState<string>("");
     const [liveRegionText, setLiveRegionText] = useLiveRegionText("");
+    const [timeBeganFillingForm, setTimeBeganFillingForm] = useState(now());
 
     const postFormData = usePOST(submitEndpoint);
 
@@ -55,6 +57,7 @@ export const Form = ({ children, ariaLabelledBy, submitEndpoint, successMessage 
             setLiveRegionText("submitting");
 
             const formData = extractFormData(form);
+            formData.timeToFillForm = `${now() - timeBeganFillingForm} milliseconds`;
 
             postFormData(formData, (ok, _, error) => {
                 setSubmitting(false);
@@ -68,7 +71,7 @@ export const Form = ({ children, ariaLabelledBy, submitEndpoint, successMessage 
                 }
             });
         }
-    }, [onSubmitObservable, setLiveRegionText, postFormData, onClearObservable]);
+    }, [onSubmitObservable, setLiveRegionText, postFormData, onClearObservable, timeBeganFillingForm]);
 
     return (<div className={"form-container"}>
             {showSuccessMessage &&

--- a/src/index.css
+++ b/src/index.css
@@ -70,3 +70,7 @@ fieldset {
     top: -10000px;
     width: 1px;
 }
+
+.display-none {
+    display: none;
+}

--- a/src/pages/accessibility-issues/AccessibilityIssues.test.tsx
+++ b/src/pages/accessibility-issues/AccessibilityIssues.test.tsx
@@ -20,19 +20,20 @@ import { INVALID_PHONE_MESSAGE } from "../../hooks/form-validation/validatePhone
 import { MISSING_REQUIRED_MESSAGE } from "../../hooks/form-validation/validateRequired";
 import { Container } from "react-dom";
 import { USER_EVENT_KEYS_FOR_TESTING_ONLY } from "../../../test/user-event-keys";
+import { HoneypotFormData } from "../../components/form/Form";
 
 describe(`${AccessibilityIssues.name} form`, () => {
     const successMessage = "Your issue has been reported, thank you!";
-    let capturedFormData: AccessibilityFormData;
+    let capturedFormData: AccessibilityFormData & HoneypotFormData;
     let user: UserEvent;
     let form: HTMLFormElement;
     let container: Container;
 
     beforeEach(() => {
         user = userEvent.setup();
-        capturedFormData = null as unknown as AccessibilityFormData;
+        capturedFormData = null as unknown as AccessibilityFormData & HoneypotFormData;
 
-        const resolver = buildPostResolver<AccessibilityFormData>({
+        const resolver = buildPostResolver<AccessibilityFormData & HoneypotFormData>({
             captor: (requestBody) => capturedFormData = requestBody,
         });
 
@@ -104,7 +105,9 @@ describe(`${AccessibilityIssues.name} form`, () => {
 
             await user.keyboard(USER_EVENT_KEYS_FOR_TESTING_ONLY.enter);
 
-            expect(capturedFormData).toEqual(stubAccessibilityFormData({ name, email, phone, comments }));
+            const { honeypotValue, timeToFillForm, ...userInputtedFormData } = capturedFormData;
+
+            expect(userInputtedFormData).toEqual(stubAccessibilityFormData({ name, email, phone, comments }));
 
             await waitFor(() => {
                 expect(screen.getByText(successMessage)).toBeInTheDocument();

--- a/src/pages/contact-us/ContactUs.test.tsx
+++ b/src/pages/contact-us/ContactUs.test.tsx
@@ -15,20 +15,21 @@ import { MISSING_REQUIRED_MESSAGE } from "../../hooks/form-validation/validateRe
 import { Container } from "react-dom";
 import { CONTACT_PAGE_HEADING, CONTACT_PAGE_IDENTIFIER, ContactFormData, ContactUs } from "./ContactUs";
 import { USER_EVENT_KEYS_FOR_TESTING_ONLY } from "../../../test/user-event-keys";
+import { HoneypotFormData } from "../../components/form/Form";
 
 describe(`${ContactUs.name} form`, () => {
     const formLabelText = "General Contact";
     const successMessage = "Your message has been sent, thank you!";
-    let capturedFormData: ContactFormData;
+    let capturedFormData: ContactFormData & HoneypotFormData;
     let user: UserEvent;
     let form: HTMLFormElement;
     let container: Container;
 
     beforeEach(() => {
         user = userEvent.setup();
-        capturedFormData = null as unknown as ContactFormData;
+        capturedFormData = null as unknown as ContactFormData & HoneypotFormData;
 
-        const resolver = buildPostResolver<ContactFormData>({
+        const resolver = buildPostResolver<ContactFormData & HoneypotFormData>({
             captor: (requestBody) => capturedFormData = requestBody,
         });
 
@@ -79,7 +80,7 @@ describe(`${ContactUs.name} form`, () => {
             expect(commentsInput).toHaveFocus();
             const comments = "There was an input that didn't have a label";
             await user.keyboard(comments);
-            
+
             await user.tab();
             expect(nameInput).toHaveFocus();
             const name = "Linda Cardellini";
@@ -100,7 +101,9 @@ describe(`${ContactUs.name} form`, () => {
 
             await user.keyboard(USER_EVENT_KEYS_FOR_TESTING_ONLY.enter);
 
-            expect(capturedFormData).toEqual(stubAccessibilityFormData({ name, email, phone, comments }));
+            const { honeypotValue, timeToFillForm, ...userInputtedFormData } = capturedFormData;
+
+            expect(userInputtedFormData).toEqual(stubAccessibilityFormData({ name, email, phone, comments }));
 
             await waitFor(() => {
                 expect(screen.getByText(successMessage)).toBeInTheDocument();

--- a/src/pages/report-id-refusal/ReportIdRefused.test.tsx
+++ b/src/pages/report-id-refusal/ReportIdRefused.test.tsx
@@ -20,20 +20,21 @@ import {
     ReportIdRefused
 } from "./ReportIdRefused";
 import { USER_EVENT_KEYS_FOR_TESTING_ONLY } from "../../../test/user-event-keys";
+import { HoneypotFormData } from "../../components/form/Form";
 
 describe(`${ReportIdRefused.name} form`, () => {
     const formLabelText = "Report Refusal of ID";
     const successMessage = "Your message has been sent, thank you!";
-    let capturedFormData: IdRefusedFormData;
+    let capturedFormData: IdRefusedFormData & HoneypotFormData;
     let user: UserEvent;
     let form: HTMLFormElement;
     let container: Container;
 
     beforeEach(() => {
         user = userEvent.setup();
-        capturedFormData = null as unknown as IdRefusedFormData;
+        capturedFormData = null as unknown as IdRefusedFormData & HoneypotFormData;
 
-        const resolver = buildPostResolver<IdRefusedFormData>({
+        const resolver = buildPostResolver<IdRefusedFormData & HoneypotFormData>({
             captor: (requestBody) => capturedFormData = requestBody,
         });
 
@@ -152,7 +153,9 @@ describe(`${ReportIdRefused.name} form`, () => {
 
             await user.keyboard(USER_EVENT_KEYS_FOR_TESTING_ONLY.enter);
 
-            expect(capturedFormData).toEqual(stubRefusedIdData({
+            const { honeypotValue, timeToFillForm, ...userInputtedFormData } = capturedFormData;
+
+            expect(userInputtedFormData).toEqual(stubRefusedIdData({
                 name,
                 email,
                 phone,

--- a/src/utilities/date-utilities.test.ts
+++ b/src/utilities/date-utilities.test.ts
@@ -1,0 +1,12 @@
+import { now } from "./date-utilities";
+
+describe("date utilities", () => {
+    test("now returns current time in milliseconds since the epoch", () => {
+        const timeFromDate = Date.now();
+        const time = now();
+        const fiveSeconds = 5000;
+
+        expect(time).toBeGreaterThanOrEqual(timeFromDate);
+        expect(time).toBeLessThanOrEqual(timeFromDate + fiveSeconds);
+    });
+});

--- a/src/utilities/date-utilities.ts
+++ b/src/utilities/date-utilities.ts
@@ -1,0 +1,1 @@
+export const now = (): number => Date.now();


### PR DESCRIPTION
https://trello.com/c/Htk6pJQU/90-deal-with-spam-form-submissions

Added a honeypot field only robots will see. If it's filled out, form submission emails include the honeypot value, the time it took to fill out the form, and the IP address the request came from.

We'll use this information to track whether we can reliable detect spam form submissions using the honeypot field or other heuristics.